### PR TITLE
Fix icon fonts with CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 Mini OS modulaire basé sur HTML/CSS/JS.
 
+Les icônes Phosphor sont désormais chargées via CDN afin d'éviter les problèmes de police manquante. Le fichier `index.html` référence directement `https://unpkg.com/phosphor-icons@1.4.2/src/css/phosphor.css`.
+
 - Voir [`docs/icon-workflow.md`](docs/icon-workflow.md) pour le workflow complet des icônes et l'intégration React/Vite/Tailwind.

--- a/docs/icon-workflow.md
+++ b/docs/icon-workflow.md
@@ -8,7 +8,7 @@ Ce mini-OS suit le thème "Minimal Red" : fonds gris sombre (#181818 → #222222
 
 ### Librairie commune
 - **Phosphor Icons** est la librairie principale utilisée.
-- Les polices `phosphor.woff2` sont chargées depuis le dossier `fonts/` et importées via `css/phosphor.css`.
+- Les polices sont désormais chargées via CDN (`https://unpkg.com/phosphor-icons@1.4.2/src/css/phosphor.css`) au lieu du dossier `fonts/` afin d'assurer leur disponibilité.
 - Les designers sélectionnent les glyphes nécessaires dans Figma à partir de la librairie Phosphor officielle.
 - Utiliser le plugin Figma "Phosphor Icons" pour importer et maintenir la librairie.
 

--- a/index.html
+++ b/index.html
@@ -12,10 +12,10 @@
     <link rel="stylesheet" href="css/sidebar-minimal.css">
     <link rel="stylesheet" href="css/theme.css">
     <link rel="stylesheet" href="css/phosphor-icons.css">
+    <link rel="stylesheet" href="https://unpkg.com/phosphor-icons@1.4.2/src/css/phosphor.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/phosphor.css">
 </head>
 <body class="theme-dark">
     <!-- Navigation latérale -->


### PR DESCRIPTION
## Summary
- load Phosphor icon CSS from CDN instead of missing local fonts
- document the CDN usage in README and icon workflow docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840c71b70d8832ebc31c1511b74b4a7