### PR TITLE
Ajout fallback Phosphor

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="css/theme.css">
     <link rel="stylesheet" href="css/phosphor-icons.css">
     <link rel="stylesheet" href="https://unpkg.com/phosphor-icons@1.4.2/src/css/phosphor.css">
+    <link rel="stylesheet" href="css/phosphor.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Notes
- Impossible d'accéder aux polices Phosphor réelles dans cet environnement, les fichiers `fonts/phosphor.woff` et `fonts/phosphor.woff2` restent donc inchangés.

## Summary
- ajout d'un lien local `css/phosphor.css` après le chargement CDN

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840cc0b0084832ead0217b3558ad25c