### PR TITLE
Met couleur des icônes

### DIFF
--- a/css/phosphor-icons.css
+++ b/css/phosphor-icons.css
@@ -9,6 +9,7 @@
     line-height: 1;
     vertical-align: middle;
     transition: all 0.2s ease;
+    color: var(--icon-color);
 }
 
 /* Icônes de navigation */
@@ -88,8 +89,11 @@
 
 /* Effets hover pour les icônes interactives */
 .nav-link:hover .ph,
+.nav-link:active .ph,
 .btn:hover .ph,
-.app-card:hover .ph {
+.btn:active .ph,
+.app-card:hover .ph,
+.app-card:active .ph {
     transform: scale(1.1);
     color: var(--primary-color);
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -5,6 +5,13 @@
     --c2r-accent: #E53935;
     --c2r-accent-hover: #F74B45;
     --c2r-accent-light: #FF7669;
+
+    /* Alias pour la coloration des icônes */
+    --primary-color: var(--c2r-accent);
+    --success-color: var(--c2r-success);
+    --warning-color: var(--c2r-warning);
+    --error-color: var(--c2r-error);
+    --info-color: var(--c2r-info);
     
     /* Espacement et bordures */
     --c2r-radius: 12px;
@@ -71,6 +78,7 @@
     --c2r-warning: #f59e0b;
     --c2r-error: #ef4444;
     --c2r-info: #3b82f6;
+    --icon-color: #ffffff;
     
     /* Ombres pour thème sombre */
     --c2r-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
@@ -106,6 +114,7 @@
     --c2r-warning: #d97706;
     --c2r-error: #dc2626;
     --c2r-info: #2563eb;
+    --icon-color: #1a1a1a;
     
     /* Ombres pour thème clair */
     --c2r-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
## Summary
- ajoute la variable CSS `--icon-color`
- couleur par défaut des icônes via `var(--icon-color)`
- les icônes deviennent rouges au survol et au clic

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840e3e4246c832ebd2327fe134c717d