### PR TITLE
Barre de navigation mobile

### DIFF
--- a/css/bottom-nav.css
+++ b/css/bottom-nav.css
@@ -1,0 +1,86 @@
+/* Barre de navigation en bas pour mobile */
+.bottom-nav {
+    display: none;
+}
+
+@media (max-width: 768px) {
+    .bottom-nav {
+        display: flex;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 60px;
+        background-color: var(--c2r-bg-card);
+        border-top: 1px solid var(--c2r-border);
+        z-index: var(--z-sidebar);
+        justify-content: space-around;
+        align-items: center;
+    }
+
+    .bottom-nav .nav-icon {
+        font-size: var(--font-size-lg);
+    }
+
+    .bottom-nav .nav-link {
+        background: none;
+        border: none;
+        color: var(--c2r-text-secondary);
+        padding: var(--c2r-spacing-sm);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .bottom-nav .nav-link.active {
+        color: var(--c2r-accent);
+    }
+
+    .bottom-nav .nav-link.active::before {
+        display: none;
+    }
+}
+
+/* Menu déroulant des applications sur mobile */
+.mobile-apps-dropdown {
+    display: none;
+    position: fixed;
+    bottom: 60px;
+    left: 0;
+    right: 0;
+    max-height: 50vh;
+    background-color: var(--c2r-bg-card);
+    border-top: 1px solid var(--c2r-border);
+    border-left: 1px solid var(--c2r-border);
+    border-right: 1px solid var(--c2r-border);
+    overflow-y: auto;
+    z-index: calc(var(--z-sidebar) + 1);
+}
+
+.mobile-apps-dropdown.show {
+    display: block;
+}
+
+.mobile-apps-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--c2r-spacing-md);
+    border-bottom: 1px solid var(--c2r-border);
+}
+
+.mobile-apps-list {
+    padding: var(--c2r-spacing-md);
+}
+
+.mobile-app-item {
+    display: flex;
+    align-items: center;
+    gap: var(--c2r-spacing-md);
+    padding: var(--c2r-spacing-sm) 0;
+    border-bottom: 1px solid var(--c2r-border);
+}
+
+.mobile-app-item:last-child {
+    border-bottom: none;
+}

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="css/apps.css">
     <link rel="stylesheet" href="css/notifications.css">
     <link rel="stylesheet" href="css/sidebar-minimal.css">
+    <link rel="stylesheet" href="css/bottom-nav.css">
     <link rel="stylesheet" href="css/theme.css">
     <link rel="stylesheet" href="css/phosphor-icons.css">
     <link rel="stylesheet" href="css/phosphor.css">
@@ -257,6 +258,30 @@
         </section>
     </main>
 
+    <!-- Barre de navigation mobile -->
+    <nav class="bottom-nav mobile-only">
+        <a href="#home" class="nav-link" data-page="home" aria-label="Accueil">
+            <span class="nav-icon" data-icon="home"></span>
+        </a>
+        <a href="#store" class="nav-link" data-page="store" aria-label="Store">
+            <span class="nav-icon" data-icon="store"></span>
+        </a>
+        <a href="#profile" class="nav-link" data-page="profile" aria-label="Profil">
+            <span class="nav-icon" data-icon="profile"></span>
+        </a>
+        <button class="nav-link" id="mobile-apps-btn" aria-label="Applications">
+            <span class="nav-icon" data-icon="list"></span>
+        </button>
+    </nav>
+
+    <div class="mobile-apps-dropdown" id="mobile-apps-dropdown">
+        <div class="mobile-apps-header">
+            <h3>Applications installées</h3>
+            <button class="close-btn" id="close-mobile-apps">&times;</button>
+        </div>
+        <div class="mobile-apps-list" id="mobile-apps-list"></div>
+    </div>
+
     <!-- Overlay mobile -->
     <div class="overlay" id="overlay"></div>
 
@@ -343,6 +368,7 @@
     <script src="js/mobile-fix.js"></script>
     
     <script src="js/sidebar-minimal.js"></script>
+    <script src="js/bottom-nav.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             IconManager.inject();

--- a/js/bottom-nav.js
+++ b/js/bottom-nav.js
@@ -1,0 +1,87 @@
+// Gestion de la barre de navigation basse et du menu des applications
+class BottomNav {
+    constructor() {
+        this.dropdown = document.getElementById('mobile-apps-dropdown');
+        this.appsBtn = document.getElementById('mobile-apps-btn');
+        this.closeBtn = document.getElementById('close-mobile-apps');
+        this.init();
+    }
+
+    init() {
+        if (this.appsBtn) {
+            this.appsBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                this.toggleMenu();
+            });
+        }
+
+        if (this.closeBtn) {
+            this.closeBtn.addEventListener('click', () => this.closeMenu());
+        }
+
+        if (this.dropdown) {
+            this.dropdown.addEventListener('click', (e) => {
+                if (e.target === this.dropdown) {
+                    this.closeMenu();
+                }
+            });
+
+            this.dropdown.addEventListener('click', (e) => {
+                const item = e.target.closest('.mobile-app-item');
+                if (item && item.dataset.app) {
+                    this.launchApp(item.dataset.app);
+                }
+            });
+        }
+    }
+
+    toggleMenu() {
+        if (!this.dropdown) return;
+        if (this.dropdown.classList.contains('show')) {
+            this.closeMenu();
+        } else {
+            this.openMenu();
+        }
+    }
+
+    openMenu() {
+        if (!this.dropdown) return;
+        this.updateAppsList();
+        this.dropdown.classList.add('show');
+    }
+
+    closeMenu() {
+        if (!this.dropdown) return;
+        this.dropdown.classList.remove('show');
+    }
+
+    updateAppsList() {
+        const appsList = document.getElementById('mobile-apps-list');
+        const appCore = window.C2R_SYSTEM?.appCore;
+        if (!appsList || !appCore) return;
+
+        const installed = appCore.getInstalledApps();
+        if (installed.length === 0) {
+            appsList.innerHTML = '<p class="no-apps">Aucune application installée</p>';
+            return;
+        }
+
+        appsList.innerHTML = installed.map(app => `
+            <div class="mobile-app-item" data-app="${app.id}">
+                <span class="app-icon">${app.icon}</span>
+                <span class="app-name">${app.name}</span>
+            </div>
+        `).join('');
+    }
+
+    launchApp(appId) {
+        if (window.C2R_SYSTEM?.uiCore) {
+            window.C2R_SYSTEM.uiCore.launchApp(appId);
+        }
+        this.closeMenu();
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    window.bottomNav = new BottomNav();
+});

--- a/js/modules/ui/ui-core.js
+++ b/js/modules/ui/ui-core.js
@@ -227,11 +227,10 @@ class UICore {
         document.querySelectorAll('.nav-link').forEach(link => {
             link.classList.remove('active');
         });
-        
-        const activeLink = document.querySelector(`[data-page="${this.currentPage}"]`);
-        if (activeLink) {
-            activeLink.classList.add('active');
-        }
+
+        document.querySelectorAll(`[data-page="${this.currentPage}"]`).forEach(link => {
+            link.classList.add('active');
+        });
     }
     
     /**


### PR DESCRIPTION
## Notes
- Ajout d'une barre fixe en bas de l'écran pour les mobiles.
- Cette barre affiche les liens vers Accueil, Store, Profil et un bouton pour la liste des applications.
- La liste des applications installées s'ouvre dans un menu déroulant.
- `UICore.updateNavigation` gère désormais toutes les cibles possédant `data-page`.
- Les tests continuent de passer.

------
https://chatgpt.com/codex/tasks/task_e_684130a3f870832e808fe4bd24030ba9