### PR TITLE
Barre de navigation mobile

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,15 @@
 ### 📄 Documentation
 - Ajout des fichiers `docs/*-readme.md` décrivant les modules.
 
+## [1.0.2] - 2025-06-05 "Mobile"
+
+### 🎉 Améliorations
+- Barre de navigation basse pour smartphones
+- Icône "list" ajoutée pour ouvrir le menu des applications
+- Bouton "Vider le cache" dans les préférences
+- Affichage de l'heure de mise à jour
+- Espacements adaptés pour ne pas masquer le contenu
+
 ## [1.0.0] - 2025-05-27 "Genesis"
 
 ### 🆕 Nouvelles fonctionnalités réelles implémentées

--- a/css/bottom-nav.css
+++ b/css/bottom-nav.css
@@ -1,0 +1,86 @@
+/* Barre de navigation en bas pour mobile */
+.bottom-nav {
+    display: none;
+}
+
+@media (max-width: 768px) {
+    .bottom-nav {
+        display: flex;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 60px;
+        background-color: var(--c2r-bg-card);
+        border-top: 1px solid var(--c2r-border);
+        z-index: var(--z-sidebar);
+        justify-content: space-around;
+        align-items: center;
+    }
+
+    .bottom-nav .nav-icon {
+        font-size: var(--font-size-lg);
+    }
+
+    .bottom-nav .nav-link {
+        background: none;
+        border: none;
+        color: var(--icon-color);
+        padding: var(--c2r-spacing-sm);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .bottom-nav .nav-link.active {
+        color: var(--c2r-accent);
+    }
+
+    .bottom-nav .nav-link.active::before {
+        display: none;
+    }
+}
+
+/* Menu déroulant des applications sur mobile */
+.mobile-apps-dropdown {
+    display: none;
+    position: fixed;
+    bottom: 60px;
+    left: 0;
+    right: 0;
+    max-height: 50vh;
+    background-color: var(--c2r-bg-card);
+    border-top: 1px solid var(--c2r-border);
+    border-left: 1px solid var(--c2r-border);
+    border-right: 1px solid var(--c2r-border);
+    overflow-y: auto;
+    z-index: calc(var(--z-sidebar) + 1);
+}
+
+.mobile-apps-dropdown.show {
+    display: block;
+}
+
+.mobile-apps-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--c2r-spacing-md);
+    border-bottom: 1px solid var(--c2r-border);
+}
+
+.mobile-apps-list {
+    padding: var(--c2r-spacing-md);
+}
+
+.mobile-app-item {
+    display: flex;
+    align-items: center;
+    gap: var(--c2r-spacing-md);
+    padding: var(--c2r-spacing-sm) 0;
+    border-bottom: 1px solid var(--c2r-border);
+}
+
+.mobile-app-item:last-child {
+    border-bottom: none;
+}

--- a/css/layout.css
+++ b/css/layout.css
@@ -582,7 +582,7 @@ body.sidebar-right .sidebar {
     }
     
     .main-content {
-        padding: calc(60px + var(--c2r-spacing-md)) var(--c2r-spacing-md) var(--c2r-spacing-md);
+        padding: calc(60px + var(--c2r-spacing-md)) var(--c2r-spacing-md) calc(60px + var(--c2r-spacing-md));
     }
     
     .page-header {
@@ -621,7 +621,7 @@ body.sidebar-right .sidebar {
 
 @media (max-width: 480px) {
     .main-content {
-        padding: calc(60px + var(--c2r-spacing-sm)) var(--c2r-spacing-sm) var(--c2r-spacing-sm);
+        padding: calc(60px + var(--c2r-spacing-sm)) var(--c2r-spacing-sm) calc(60px + var(--c2r-spacing-sm));
     }
     
     .welcome-card {

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="css/apps.css">
     <link rel="stylesheet" href="css/notifications.css">
     <link rel="stylesheet" href="css/sidebar-minimal.css">
+    <link rel="stylesheet" href="css/bottom-nav.css">
     <link rel="stylesheet" href="css/theme.css">
     <link rel="stylesheet" href="css/phosphor-icons.css">
     <link rel="stylesheet" href="css/phosphor.css">
@@ -86,6 +87,7 @@
                 <div class="welcome-header">
                     <h1>Bienvenue sur C2R OS</h1>
                     <p class="system-version">C2R OS v1.0.0 – Build 2025-05-27</p>
+                    <p class="update-time text-small">Mis à jour le <span id="update-time"></span></p>
                 </div>
                 
                 <div class="welcome-content">
@@ -183,6 +185,10 @@
                             </label>
                         </label>
                     </div>
+
+                    <button class="btn btn-secondary" id="clear-cache-user" aria-label="Vider le cache">
+                        Vider le cache
+                    </button>
                 </div>
             </div>
         </section>
@@ -256,6 +262,30 @@
             </div>
         </section>
     </main>
+
+    <!-- Barre de navigation mobile -->
+    <nav class="bottom-nav mobile-only">
+        <a href="#home" class="nav-link" data-page="home" aria-label="Accueil">
+            <span class="nav-icon" data-icon="home"></span>
+        </a>
+        <a href="#store" class="nav-link" data-page="store" aria-label="Store">
+            <span class="nav-icon" data-icon="store"></span>
+        </a>
+        <a href="#profile" class="nav-link" data-page="profile" aria-label="Profil">
+            <span class="nav-icon" data-icon="profile"></span>
+        </a>
+        <button class="nav-link" id="mobile-apps-btn" aria-label="Applications">
+            <span class="nav-icon" data-icon="list"></span>
+        </button>
+    </nav>
+
+    <div class="mobile-apps-dropdown" id="mobile-apps-dropdown">
+        <div class="mobile-apps-header">
+            <h3>Applications installées</h3>
+            <button class="close-btn" id="close-mobile-apps">&times;</button>
+        </div>
+        <div class="mobile-apps-list" id="mobile-apps-list"></div>
+    </div>
 
     <!-- Overlay mobile -->
     <div class="overlay" id="overlay"></div>
@@ -343,6 +373,7 @@
     <script src="js/mobile-fix.js"></script>
     
     <script src="js/sidebar-minimal.js"></script>
+    <script src="js/bottom-nav.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             IconManager.inject();

--- a/js/bottom-nav.js
+++ b/js/bottom-nav.js
@@ -1,0 +1,87 @@
+// Gestion de la barre de navigation basse et du menu des applications
+class BottomNav {
+    constructor() {
+        this.dropdown = document.getElementById('mobile-apps-dropdown');
+        this.appsBtn = document.getElementById('mobile-apps-btn');
+        this.closeBtn = document.getElementById('close-mobile-apps');
+        this.init();
+    }
+
+    init() {
+        if (this.appsBtn) {
+            this.appsBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                this.toggleMenu();
+            });
+        }
+
+        if (this.closeBtn) {
+            this.closeBtn.addEventListener('click', () => this.closeMenu());
+        }
+
+        if (this.dropdown) {
+            this.dropdown.addEventListener('click', (e) => {
+                if (e.target === this.dropdown) {
+                    this.closeMenu();
+                }
+            });
+
+            this.dropdown.addEventListener('click', (e) => {
+                const item = e.target.closest('.mobile-app-item');
+                if (item && item.dataset.app) {
+                    this.launchApp(item.dataset.app);
+                }
+            });
+        }
+    }
+
+    toggleMenu() {
+        if (!this.dropdown) return;
+        if (this.dropdown.classList.contains('show')) {
+            this.closeMenu();
+        } else {
+            this.openMenu();
+        }
+    }
+
+    openMenu() {
+        if (!this.dropdown) return;
+        this.updateAppsList();
+        this.dropdown.classList.add('show');
+    }
+
+    closeMenu() {
+        if (!this.dropdown) return;
+        this.dropdown.classList.remove('show');
+    }
+
+    updateAppsList() {
+        const appsList = document.getElementById('mobile-apps-list');
+        const appCore = window.C2R_SYSTEM?.appCore;
+        if (!appsList || !appCore) return;
+
+        const installed = appCore.getInstalledApps();
+        if (installed.length === 0) {
+            appsList.innerHTML = '<p class="no-apps">Aucune application installée</p>';
+            return;
+        }
+
+        appsList.innerHTML = installed.map(app => `
+            <div class="mobile-app-item" data-app="${app.id}">
+                <span class="app-icon">${app.icon}</span>
+                <span class="app-name">${app.name}</span>
+            </div>
+        `).join('');
+    }
+
+    launchApp(appId) {
+        if (window.C2R_SYSTEM?.uiCore) {
+            window.C2R_SYSTEM.uiCore.launchApp(appId);
+        }
+        this.closeMenu();
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    window.bottomNav = new BottomNav();
+});

--- a/js/main.js
+++ b/js/main.js
@@ -61,6 +61,8 @@ function initializeUserInterface() {
             showAuthModal('login');
         }, 1000);
     }
+
+    displayUpdateTime();
 }
 
 /**
@@ -121,6 +123,12 @@ function setupGlobalEventHandlers() {
     
     // Gestionnaires admin
     setupAdminHandlers();
+
+    // Bouton de vidage du cache pour l'utilisateur
+    const userCacheBtn = document.getElementById('clear-cache-user');
+    if (userCacheBtn) {
+        userCacheBtn.addEventListener('click', handleClearCache);
+    }
     
     // Gestionnaires de drag & drop pour réorganiser les apps
     setupDragAndDrop();
@@ -334,9 +342,9 @@ function handleSystemReset() {
 function handleClearCache() {
     const uiCore = window.C2R_SYSTEM?.uiCore;
     const userCore = window.C2R_SYSTEM?.userCore;
-    
-    if (!userCore?.isAdmin()) {
-        uiCore?.showNotification('Accès refusé - Admin requis', 'error');
+
+    if (!userCore?.getCurrentUser()) {
+        uiCore?.showNotification('Veuillez vous connecter pour continuer', 'error');
         return;
     }
     
@@ -451,6 +459,17 @@ function displayBootInfo(system) {
         const config = window.C2R_CONFIG;
         const version = config.getVersionInfo();
         versionElement.textContent = `${config.system.name} ${version.fullVersion}`;
+    }
+}
+
+/**
+ * Afficher l'heure de la dernière mise à jour
+ */
+function displayUpdateTime() {
+    const el = document.getElementById('update-time');
+    if (el) {
+        const now = new Date();
+        el.textContent = now.toLocaleString();
     }
 }
 

--- a/js/modules/ui/icon-manager.js
+++ b/js/modules/ui/icon-manager.js
@@ -33,6 +33,7 @@
         mail: '<i class="ph ph-envelope"></i>',
         phone: '<i class="ph ph-phone"></i>',
         cart: '<i class="ph ph-shopping-cart"></i>',
+        list: '<i class="ph ph-list"></i>',
         play: '<i class="ph ph-play"></i>',
         pause: '<i class="ph ph-pause"></i>',
         checkcircle: '<i class="ph ph-check-circle"></i>',

--- a/js/modules/ui/ui-core.js
+++ b/js/modules/ui/ui-core.js
@@ -227,11 +227,10 @@ class UICore {
         document.querySelectorAll('.nav-link').forEach(link => {
             link.classList.remove('active');
         });
-        
-        const activeLink = document.querySelector(`[data-page="${this.currentPage}"]`);
-        if (activeLink) {
-            activeLink.classList.add('active');
-        }
+
+        document.querySelectorAll(`[data-page="${this.currentPage}"]`).forEach(link => {
+            link.classList.add('active');
+        });
     }
     
     /**


### PR DESCRIPTION
## Notes
- Ajout d'une icône `list` pour le bouton d'applications dans le changelog.
- Les tests échouent car `jest` est manquant dans l'environnement d'exécution.

## Summary
- Barre de navigation en bas de l'écran pour smartphone avec les icônes Accueil, Store, Profil et un bouton ouvrant la liste des applications installées.
- Icône `list` disponible dans `IconManager`.
- Bouton « Vider le cache » accessible aux utilisateurs dans les préférences.
- Affichage de la date de mise à jour sur la page d'accueil.
- Ajustements de l'espacement du contenu principal pour ne pas être caché sur mobile.

## Testing
- ❌ `npm test` échoue : `jest` manquant

------
https://chatgpt.com/codex/tasks/task_e_684130a3f870832e808fe4bd24030ba9