### PR TITLE
Ajout styles icônes thème sombre/clair

### DIFF
--- a/css/phosphor-icons.css
+++ b/css/phosphor-icons.css
@@ -202,3 +202,19 @@
     margin-right: 0.5rem;
     color: var(--text-secondary);
 }
+
+/* Ajout : gestion couleurs icônes thème clair/sombre */
+.icon-button .ph {
+    color: #000;
+    transition: color 0.2s ease;
+}
+
+.dark-mode .icon-button .ph,
+.theme-dark .icon-button .ph {
+    color: #fff;
+}
+
+.icon-button:hover .ph,
+.icon-button:active .ph {
+    color: #E53935;
+}


### PR DESCRIPTION
## Notes
- Ajout d'une section dédiée pour gérer la couleur des icônes selon le thème.
- Les icônes ayant la classe `icon-button` s'affichent en blanc dans `.dark-mode` (ou `.theme-dark`) et en noir sinon, avec un survol/clic rouge.

## Test
- `npm test` *(échec : jest manquant)*

------
https://chatgpt.com/codex/tasks/task_e_6841c77871fc832eae177bbf7f278a85