### PR TITLE
Ajout styles icônes thème sombre/clair

### DIFF
--- a/css/phosphor-icons.css
+++ b/css/phosphor-icons.css
@@ -202,3 +202,26 @@
     margin-right: 0.5rem;
     color: var(--text-secondary);
 }
+
+/* Ajout : gestion couleurs icônes thème clair/sombre */
+.icon-button .ph,
+.nav-icon .ph {
+    color: var(--icon-color);
+    transition: color 0.2s ease;
+}
+
+/* Compatibilité anciens thèmes */
+.dark-mode .icon-button .ph,
+.dark-mode .nav-icon .ph {
+    color: #fff;
+}
+
+.theme-light .icon-button .ph,
+.theme-light .nav-icon .ph {
+    color: #000;
+}
+
+.icon-button:hover .ph,
+.icon-button:active .ph {
+    color: var(--primary-color);
+}


### PR DESCRIPTION
## Notes
- Ajout d'une section dédiée pour gérer la couleur des icônes selon le thème.
- Les icônes ayant la classe `icon-button` et `nav-icon` s'affichent en blanc en `.theme-dark` ou `.dark-mode`, noir en `.theme-light`, avec un survol/clic rouge.

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841c77871fc832eae177bbf7f278a85