### PR TITLE
Correction couleurs des icônes

### DIFF
--- a/css/phosphor-icons.css
+++ b/css/phosphor-icons.css
@@ -202,3 +202,23 @@
     margin-right: 0.5rem;
     color: var(--text-secondary);
 }
+
+/* Ajout : gestion couleurs icônes thème clair/sombre */
+.theme-dark .ph,
+.dark-mode .ph {
+    color: #fff;
+}
+
+.theme-light .ph {
+    color: #000;
+}
+
+.icon-button .ph,
+.nav-icon .ph {
+    transition: color 0.2s ease;
+}
+
+.icon-button:hover .ph,
+.icon-button:active .ph {
+    color: var(--primary-color);
+}


### PR DESCRIPTION
## Notes
- Unification de la couleur par défaut des icônes via `.theme-dark` ou `.theme-light`.
- Les icônes prennent la couleur rouge au survol grâce à `icon-button`.

## Test
- `npm test` *(échoué : jest non installé)*


------
https://chatgpt.com/codex/tasks/task_e_6841c77871fc832eae177bbf7f278a85