### PR TITLE
Nettoyage des styles d'icônes

### DIFF
--- a/css/phosphor-icons.css
+++ b/css/phosphor-icons.css
@@ -203,8 +203,7 @@
     color: var(--text-secondary);
 }
 
-/* Ajout : gestion couleurs icônes thème clair/sombre */
-5qj3sj-codex/2025-06-05
+/* Couleurs des icônes selon le thème */
 .theme-dark .ph,
 .dark-mode .ph {
     color: #fff;
@@ -217,22 +216,10 @@
 .icon-button .ph,
 .nav-icon .ph {
     transition: color 0.2s ease;
-
-.icon-button .ph {
-    color: #000;
-    transition: color 0.2s ease;
-}
-
-.dark-mode .icon-button .ph {
-    color: #fff;
-main
 }
 
 .icon-button:hover .ph,
 .icon-button:active .ph {
-5qj3sj-codex/2025-06-05
     color: var(--primary-color);
-
-    color: #E53935;
- main
 }
+


### PR DESCRIPTION
## Notes
- Suppression des anciennes règles `.icon-button .ph` et `.dark-mode .icon-button .ph`
- Ajout d'un bloc unifié pour gérer les couleurs d'icônes selon le thème
- Les icônes des boutons changent de couleur au survol/activation via `var(--primary-color)`
- Vérification de la présence de `--primary-color` dans `theme.css`
- Tests `npm` exécutés avec succès

------
https://chatgpt.com/codex/tasks/task_e_6841d9425ec0832eaad12749908026b0