### PR TITLE
Ajout bouton +/poubelle dans le Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Les icônes Font Awesome sont désormais chargées via CDN afin d'éviter les pr
 
 - Voir [`docs/icon-workflow.md`](docs/icon-workflow.md) pour le workflow complet des icônes et l'intégration React/Vite/Tailwind.
 - La documentation de chaque module se trouve dans `docs/*-readme.md`.
+- Le Store présente un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge lorsqu'elle est installée.
 
 ## Aperçu local
 

--- a/css/icons.css
+++ b/css/icons.css
@@ -50,6 +50,14 @@
     display: block;
 }
 
+.app-toggle-btn .icon {
+    color: white;
+}
+
+.app-toggle-btn.installed .icon {
+    color: var(--error-color);
+}
+
 /* Icônes de statut */
 .status-icon .icon {
     font-size: 1rem;

--- a/css/layout.css
+++ b/css/layout.css
@@ -361,6 +361,19 @@ body.sidebar-right .sidebar {
     margin-top: auto;
 }
 
+.app-toggle-btn {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: var(--c2r-spacing-sm);
+    border-radius: var(--c2r-radius);
+    transition: var(--c2r-transition);
+}
+
+.app-toggle-btn:hover {
+    background-color: var(--c2r-bg-hover);
+}
+
 /* Profil */
 .profile-content {
     display: grid;

--- a/docs/app-readme.md
+++ b/docs/app-readme.md
@@ -3,3 +3,6 @@
 Charge les applications intégrées et gère leur installation ou suppression. Le
 module maintient la liste des apps disponibles et leur état (installée ou non).
 Les applications peuvent être étendues par la suite pour enrichir le système.
+
+Le module est utilisé par `UICore.toggleApp()` pour installer ou désinstaller
+les applications depuis le Store.

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -3,3 +3,8 @@
 S'occupe du thème, de la navigation et des notifications. Il adapte l'interface
 aux différents écrans et applique les préférences de l'utilisateur. C'est lui
 qui met à jour la sidebar et les pages lors des interactions.
+
+Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour
+installer ou désinstaller une application. Un bouton unique affiche l'icône
+`plus` en blanc tant que l'application n'est pas installée, puis une icône de
+poubelle rouge une fois installée.

--- a/js/modules/ui/ui-core.js
+++ b/js/modules/ui/ui-core.js
@@ -281,21 +281,36 @@ class UICore {
                     <span>Taille: ${app.size}</span>
                 </div>
                 <div class="app-actions">
-                    ${appCore.isInstalled(app.id) ? 
-                        `<button class="btn btn-danger btn-small" onclick="window.C2R_SYSTEM.appCore.uninstallApp('${app.id}'); window.C2R_SYSTEM.uiCore.refreshApplicationsList();" aria-label="Désinstaller ${app.name}">
-                            <span>${IconManager.getIcon('uninstall')}</span> Désinstaller
-                        </button>` :
-                        `<button class="btn btn-primary btn-small" onclick="window.C2R_SYSTEM.appCore.installApp('${app.id}'); window.C2R_SYSTEM.uiCore.refreshApplicationsList(); window.C2R_SYSTEM.uiCore.showNotification('${app.name} installée!', 'success');" aria-label="Installer ${app.name}">
-                            <span>${IconManager.getIcon('install')}</span> Installer
-                        </button>`
-                    }
-                    ${appCore.isInstalled(app.id) ? 
-                        `<span class="badge badge-success">${IconManager.getIcon('check')} Installée</span>` : 
-                        `<span class="badge badge-info">${IconManager.getIcon('install')} Disponible</span>`
-                    }
+                    <button class="app-toggle-btn ${appCore.isInstalled(app.id) ? 'installed' : ''}"
+                            onclick="window.C2R_SYSTEM.uiCore.toggleApp('${app.id}')"
+                            aria-label="${appCore.isInstalled(app.id) ? 'Désinstaller' : 'Installer'}">
+                        <span class="icon">${IconManager.getIcon(appCore.isInstalled(app.id) ? 'uninstall' : 'install')}</span>
+                    </button>
                 </div>
             </div>
         `).join('');
+    }
+
+    /**
+     * Installer ou désinstaller une application selon son état actuel
+     * @param {string} appId - ID de l'application
+     */
+    toggleApp(appId) {
+        const appCore = window.C2R_SYSTEM?.appCore;
+        if (!appCore) return;
+
+        if (appCore.isInstalled(appId)) {
+            appCore.uninstallApp(appId);
+            this.showNotification('Application désinstallée', 'warning');
+        } else {
+            appCore.installApp(appId);
+            this.showNotification('Application installée', 'success');
+        }
+
+        this.refreshApplicationsList();
+        if (this.currentPage === 'profile') {
+            this.refreshUserProfile();
+        }
     }
     
     /**


### PR DESCRIPTION
## Résumé
- simplifie les actions du store en un seul bouton
- ajout de la méthode `toggleApp` côté UI
- styles pour le nouveau bouton et mise à jour des icônes
- documentation mise à jour (README et docs)

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f3019254832e8e8e2a54428a936b