### PR TITLE
Fix icone apps mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Les icônes Font Awesome sont désormais chargées via CDN afin d'éviter les pr
 - Voir [`docs/icon-workflow.md`](docs/icon-workflow.md) pour le workflow complet des icônes et l'intégration React/Vite/Tailwind.
 - La documentation de chaque module se trouve dans `docs/*-readme.md`.
 - Le Store présente un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge lorsqu'elle est installée.
+- En affichage mobile, un bouton "Applications" est disponible dans la barre de navigation basse.
 
 ## Aperçu local
 

--- a/changelog.md
+++ b/changelog.md
@@ -220,6 +220,7 @@ C2R_DEBUG.installAllApps()     // Installer toutes les apps
 - Ajout d'appels directs à `updateSidebarApps()`
 - Implémentation de `updateConnectionStatus()`
 - Amélioration de la persistance des sessions
+- Correction de l'affichage de l'icône **Applications** dans la barre de navigation mobile
 
 ---
 

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -8,3 +8,7 @@ Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour
 installer ou désinstaller une application. Un bouton unique affiche l'icône
 `plus` en blanc tant que l'application n'est pas installée, puis une icône de
 poubelle rouge une fois installée.
+
+En mode mobile, la barre de navigation basse comprend un bouton **Applications**.
+L'icône correspondante est maintenant correctement chargée grâce à l'ajout de
+l'icône `list` dans `IconManager`.

--- a/js/modules/ui/icon-manager.js
+++ b/js/modules/ui/icon-manager.js
@@ -8,6 +8,7 @@
         install: '<i class="icon fa-solid fa-plus"></i>',
         uninstall: '<i class="icon fa-solid fa-trash"></i>',
         check: '<i class="icon fa-solid fa-check"></i>',
+        list: '<i class="icon fa-solid fa-list"></i>',
         signout: '<i class="icon fa-solid fa-right-from-bracket"></i>',
         search: '<i class="icon fa-solid fa-magnifying-glass"></i>',
         idea: '<i class="icon fa-solid fa-lightbulb"></i>',


### PR DESCRIPTION
## Summary
- ajoute l'icône `list` dans `IconManager`
- référence du bouton Applications mobile dans la doc UI et le README
- note de correction dans le changelog

## Testing
- `npm test` *(échoue : jest indisponible)*

------
https://chatgpt.com/codex/tasks/task_e_684202345dec832eb7b35e8fec69ccdb