### PR TITLE
Fix store icons color and size

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Les icônes Font Awesome sont désormais chargées via CDN afin d'éviter les pr
 - Voir [`docs/icon-workflow.md`](docs/icon-workflow.md) pour le workflow complet des icônes et l'intégration React/Vite/Tailwind.
 - La documentation de chaque module se trouve dans `docs/*-readme.md`.
 - Le Store présente un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge lorsqu'elle est installée.
+- En mode sombre, la poubelle conserve sa couleur rouge et la taille des icônes d'installation a été réduite pour un meilleur rendu mobile.
 - En affichage mobile, un bouton "Applications" est disponible dans la barre de navigation basse.
 
 ## Aperçu local

--- a/css/icons.css
+++ b/css/icons.css
@@ -52,6 +52,11 @@
 
 .app-toggle-btn .icon {
     color: white;
+    font-size: 1.5rem;
+}
+
+.app-actions .app-toggle-btn .icon {
+    font-size: 1.5rem;
 }
 
 .app-toggle-btn.installed .icon {
@@ -160,15 +165,19 @@
     .icon {
         font-size: 1.1rem;
     }
-    
+
     .app-icon .icon {
         font-size: 1.8rem;
     }
-    
+
     .app-card .icon {
         font-size: 2rem;
     }
-    
+
+    .app-actions .app-toggle-btn .icon {
+        font-size: 1.3rem;
+    }
+
     .nav-icon .icon {
         font-size: 1rem;
     }
@@ -182,6 +191,7 @@
 .theme-dark .search-icon .icon {
     color: var(--text-secondary);
 }
+
 
 /* Icônes dans les notifications */
 .notification .icon {
@@ -215,6 +225,16 @@
 .theme-dark .icon,
 .dark-mode .icon {
     color: #fff;
+}
+
+.theme-dark .app-toggle-btn .icon,
+.dark-mode .app-toggle-btn .icon {
+    color: white;
+}
+
+.theme-dark .app-toggle-btn.installed .icon,
+.dark-mode .app-toggle-btn.installed .icon {
+    color: var(--error-color);
 }
 
 .theme-light .icon {

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -8,6 +8,8 @@ Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour
 installer ou désinstaller une application. Un bouton unique affiche l'icône
 `plus` en blanc tant que l'application n'est pas installée, puis une icône de
 poubelle rouge une fois installée.
+L'affichage sombre maintient cette couleur rouge et la taille de ce bouton a
+été réduite pour un meilleur rendu sur mobile.
 
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**.
 L'icône correspondante est maintenant correctement chargée grâce à l'ajout de


### PR DESCRIPTION
## Summary
- correct store icon colours in dark theme
- reduce install/uninstall icon sizes for better mobile rendering
- update docs about new icon behaviour

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842046511e8832e9f8330de6d832688