### PR TITLE
Fix store icon layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Les icônes Font Awesome sont désormais chargées via CDN afin d'éviter les pr
 - Voir [`docs/icon-workflow.md`](docs/icon-workflow.md) pour le workflow complet des icônes et l'intégration React/Vite/Tailwind.
 - La documentation de chaque module se trouve dans `docs/*-readme.md`.
 - Le Store présente un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge lorsqu'elle est installée.
+- Les boutons d'installation et de désinstallation affichent désormais l'icône à droite du texte pour une meilleure lisibilité.
 - En mode sombre, la poubelle conserve sa couleur rouge et la taille des icônes d'installation a été réduite pour un meilleur rendu mobile.
 - En affichage mobile, un bouton "Applications" est disponible dans la barre de navigation basse.
 

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -7,7 +7,7 @@ qui met à jour la sidebar et les pages lors des interactions.
 Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour
 installer ou désinstaller une application. Un bouton unique affiche l'icône
 `plus` en blanc tant que l'application n'est pas installée, puis une icône de
-poubelle rouge une fois installée.
+poubelle rouge une fois installée. Les boutons placent désormais l'icône à droite du texte.
 L'affichage sombre maintient cette couleur rouge et la taille de ce bouton a
 été réduite pour un meilleur rendu sur mobile.
 

--- a/js/main.js
+++ b/js/main.js
@@ -214,10 +214,10 @@ function renderFilteredApps(apps) {
             <div class="app-actions">
                 ${appCore.isInstalled(app.id) ?
                     `<button class="btn btn-danger btn-small" onclick="handleAppUninstall('${app.id}')" aria-label="Désinstaller ${app.name}">
-                        <span>${IconManager.getIcon('uninstall')}</span> Désinstaller
+                        Désinstaller <span>${IconManager.getIcon('uninstall')}</span>
                     </button>` :
                     `<button class="btn btn-primary btn-small" onclick="handleAppInstall('${app.id}')" aria-label="Installer ${app.name}">
-                        <span>${IconManager.getIcon('install')}</span> Installer
+                        Installer <span>${IconManager.getIcon('install')}</span>
                     </button>`
                 }
                 ${appCore.isInstalled(app.id) ?


### PR DESCRIPTION
## Summary
- move install/uninstall icons to the right of text in js/main
- document new icon placement in README and docs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684206d778d0832ebf26dd364a0eeb7f