### PR TITLE
Correction alignement icônes store

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Les icônes Font Awesome sont désormais chargées via CDN afin d'éviter les pr
 - La documentation de chaque module se trouve dans `docs/*-readme.md`.
 - Le Store présente un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge lorsqu'elle est installée.
 - Les boutons d'installation et de désinstallation affichent désormais l'icône à droite du texte pour une meilleure lisibilité.
+- Sur les tuiles du Store, l'icône d'installation ou de suppression est alignée à droite pour une interface plus claire.
 - En mode sombre, la poubelle conserve sa couleur rouge et la taille des icônes d'installation a été réduite pour un meilleur rendu mobile.
 - En affichage mobile, un bouton "Applications" est disponible dans la barre de navigation basse.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # 📝 C2R OS - Journal des modifications
 
+## [1.0.2] - 2025-06-05 "UX"
+
+### ✨ Améliorations de l'interface
+- Alignement des icônes "installer" et "poubelle" à droite des tuiles du Store pour plus de cohérence.
+
 ## [1.0.1] - 2025-06-05 "Docs"
 
 ### 📄 Documentation

--- a/css/layout.css
+++ b/css/layout.css
@@ -359,6 +359,7 @@ body.sidebar-right .sidebar {
     display: flex;
     gap: var(--c2r-spacing-sm);
     margin-top: auto;
+    justify-content: flex-end;
 }
 
 .app-toggle-btn {


### PR DESCRIPTION
## Résumé
- aligner la zone `.app-actions` à droite dans `layout.css`
- mentionner ce changement dans `README.md`
- ajouter une entrée de changelog

## Tests
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68420beb88b8832ebe6da954032ea3bc