### PR TITLE
Déplacement du bouton de réduction dans la sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Les icônes Font Awesome sont désormais chargées via CDN afin d'éviter les pr
 - Sur les tuiles du Store, l'icône d'installation ou de suppression est alignée à droite pour une interface plus claire.
 - En mode sombre, la poubelle conserve sa couleur rouge et la taille des icônes d'installation a été réduite pour un meilleur rendu mobile.
 - En affichage mobile, un bouton "Applications" est disponible dans la barre de navigation basse.
+- La barre latérale possède désormais un bouton intégré permettant de passer en mode compact. Ce bouton se place automatiquement de l'autre côté si la barre est à droite.
 
 ## Aperçu local
 

--- a/changelog.md
+++ b/changelog.md
@@ -233,3 +233,9 @@ C2R_DEBUG.installAllApps()     // Installer toutes les apps
 - Ajout du fichier `docs/icon-workflow.md` pour la gestion Design → Dev des icônes.
 - Migration vers la librairie **Font Awesome** pour toutes les icônes (chargement via CDN).
 *Journal maintenu à jour à chaque modification significative du système*
+
+## [1.0.3] - 2025-06-06 "UI"
+
+### ✨ Améliorations de la sidebar
+- Le bouton de réduction est désormais intégré à la barre latérale elle-même,
+  placé dans l'en-tête. Sa position s'adapte lorsque la barre passe à droite.

--- a/css/sidebar-minimal.css
+++ b/css/sidebar-minimal.css
@@ -285,9 +285,9 @@ body.minimal-sidebar .btn-logout:active {
 
 /* Bouton de basculement */
 .sidebar-toggle-minimal {
-    position: fixed;
-    top: 20px;
-    right: 20px;
+    position: absolute;
+    top: 10px;
+    right: 10px;
     background-color: var(--c2r-bg-card);
     border: 1px solid var(--c2r-border);
     border-radius: 50%;
@@ -300,6 +300,11 @@ body.minimal-sidebar .btn-logout:active {
     z-index: 1001;
     transition: var(--c2r-transition);
     font-size: 18px;
+}
+
+body.sidebar-right .sidebar .sidebar-toggle-minimal {
+    right: auto;
+    left: 10px;
 }
 
 .sidebar-toggle-minimal:hover {

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -14,3 +14,7 @@ L'affichage sombre maintient cette couleur rouge et la taille de ce bouton a
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**.
 L'icône correspondante est maintenant correctement chargée grâce à l'ajout de
 l'icône `list` dans `IconManager`.
+
+La sidebar propose également un mode compact activé par un bouton placé
+directement dans son en-tête. Ce bouton se situe en haut à droite ou à gauche
+suivant la position de la barre et permet d'afficher uniquement les icônes.

--- a/js/sidebar-minimal.js
+++ b/js/sidebar-minimal.js
@@ -22,17 +22,20 @@ class SidebarMinimal {
      * Créer le bouton de basculement
      */
     createToggleButton() {
+        const sidebar = document.getElementById('sidebar');
+        if (!sidebar) return;
+
         const toggleBtn = document.createElement('button');
         toggleBtn.className = 'sidebar-toggle-minimal';
         toggleBtn.innerHTML = '⚡';
         toggleBtn.title = 'Basculer sidebar minimaliste';
         toggleBtn.setAttribute('aria-label', 'Basculer sidebar minimaliste');
-        
+
         toggleBtn.addEventListener('click', () => {
             this.toggleMinimalSidebar();
         });
-        
-        document.body.appendChild(toggleBtn);
+
+        sidebar.appendChild(toggleBtn);
     }
     
     /**


### PR DESCRIPTION
## Résumé
- le bouton de réduction de la sidebar est maintenant ajouté dans l'en-tête de la barre
- position ajustée pour les barres à droite
- documentation mise à jour (README, changelog et ui-readme)
- tests exécutés avec succès

## Test
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68420e6f45e8832ebd9a9b6d838dbfbb