### PR TITLE
Fix icons style on store filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Les icônes Font Awesome sont chargées via CDN. Le fichier `index.html` référ
 - La documentation de chaque module se trouve dans `docs/*-readme.md`.
 - Le Store propose un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge.
 - Les icônes d'installation sont alignées à droite des tuiles pour plus de clarté.
+- Lors d'une recherche ou d'un filtre dans le Store, ces icônes conservent le même design.
 - En mode sombre, la poubelle reste rouge et la taille des icônes est réduite pour le mobile.
 - En affichage mobile, un bouton **Applications** apparaît dans la barre de navigation basse.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.

--- a/changelog.md
+++ b/changelog.md
@@ -251,3 +251,8 @@ Documentation
 
 ### ♻️ Navigation mobile simplifiée
 - Suppression du menu hamburger au profit de la barre de navigation basse.
+
+## [1.0.5] - 2025-06-08 "Fix"
+
+### 🐛 Correctifs
+- Les icônes "installer" et "poubelle" conservent leur design lors de la recherche ou du filtrage dans le Store.

--- a/js/main.js
+++ b/js/main.js
@@ -212,18 +212,11 @@ function renderFilteredApps(apps) {
                 <strong>Permissions:</strong> ${app.permissions.join(', ') || 'Aucune'}
             </div>
             <div class="app-actions">
-                ${appCore.isInstalled(app.id) ?
-                    `<button class="btn btn-danger btn-small" onclick="handleAppUninstall('${app.id}')" aria-label="Désinstaller ${app.name}">
-                        Désinstaller <span>${IconManager.getIcon('uninstall')}</span>
-                    </button>` :
-                    `<button class="btn btn-primary btn-small" onclick="handleAppInstall('${app.id}')" aria-label="Installer ${app.name}">
-                        Installer <span>${IconManager.getIcon('install')}</span>
-                    </button>`
-                }
-                ${appCore.isInstalled(app.id) ?
-                    `<span class="badge badge-success">${IconManager.getIcon('check')} Installée</span>` :
-                    `<span class="badge badge-info">${IconManager.getIcon('install')} Disponible</span>`
-                }
+                <button class="app-toggle-btn ${appCore.isInstalled(app.id) ? 'installed' : ''}"
+                        onclick="${appCore.isInstalled(app.id) ? `handleAppUninstall('${app.id}')` : `handleAppInstall('${app.id}')`}"
+                        aria-label="${appCore.isInstalled(app.id) ? `Désinstaller ${app.name}` : `Installer ${app.name}`}">
+                    <span class="icon">${IconManager.getIcon(appCore.isInstalled(app.id) ? 'uninstall' : 'install')}</span>
+                </button>
             </div>
         </div>
     `).join('');


### PR DESCRIPTION
## Summary
- keep custom icon design when searching or filtering in the store
- document this behaviour in README and changelog

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421b28f008832eb813aa0abd380b8a