### PR TITLE
Fix mobile trash icon color

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,28 +6,6 @@ Les icônes Font Awesome sont chargées via CDN. Le fichier `index.html` référ
 
 - Voir [`docs/icon-workflow.md`](docs/icon-workflow.md) pour le workflow complet des icônes.
 - La documentation de chaque module se trouve dans `docs/*-readme.md`.
-79080s-codex/2025-06-05
-- La liste des pop-ups indispensables figure dans
-  [`docs/popup-readme.md`](docs/popup-readme.md).
-=======
-gomuxy-codex/2025-06-05
-- Le Store présente un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge lorsqu'elle est installée.
-- Les boutons d'installation et de désinstallation affichent désormais l'icône à droite du texte pour une meilleure lisibilité.
-- Sur les tuiles du Store, l'icône d'installation ou de suppression est alignée à droite pour une interface plus claire.
-- En mode sombre, la poubelle conserve sa couleur rouge et la taille des icônes d'installation a été réduite pour un meilleur rendu mobile.
-- En affichage mobile, un bouton "Applications" est disponible dans la barre de navigation basse.
-- Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer directement dans la page Profil, sur mobile comme sur ordinateur.
-uc0ehg-codex/2025-06-05
-- Le menu hamburger a disparu : la barre de navigation basse gère désormais la navigation mobile.
-- La barre latérale adopte désormais un dégradé de gris avec ombre portée pour mieux s'intégrer au thème sombre ou clair.
-- La barre latérale possède désormais un bouton intégré permettant de passer en mode compact. Ce bouton se place automatiquement de l'autre côté si la barre est à droite.
-- Correction de la couleur bleue des icônes de désinstallation sur mobile ; elles apparaissent maintenant en rouge.
-=======
-- La barre latérale dispose d'un bouton intégré pour passer en mode compact. L'icône en chevron s'inverse automatiquement selon la position de la barre.
-- Le menu hamburger a disparu : la barre de navigation basse gère désormais la navigation mobile.
-- La barre latérale adopte désormais un dégradé de gris avec ombre portée pour mieux s'intégrer au thème sombre ou clair.
-=======
-main
 - Le Store propose un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge.
 - Les icônes d'installation sont alignées à droite des tuiles pour plus de clarté.
 - Lors d'une recherche ou d'un filtre dans le Store, ces icônes conservent le même design.
@@ -36,8 +14,6 @@ main
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - La barre latérale intègre un bouton de réduction : l'icône passe d'une croix à un petit carré suivant l'état de la barre.
 - La barre latérale utilise un dégradé de gris et une ombre portée pour s'intégrer au thème.
-main
-main
 
 ## Aperçu local
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,4 @@
-uc0ehg-codex/2025-06-05
 # 📝 C2R OS - Journal des modifications
-=======
-# 📝 C2R OS - Journal des modifications
-main
 
 ## [1.1.0] - 2025-06-06 "DragDrop"
 
@@ -20,37 +16,7 @@ main
 ### 📄 Documentation
 - Ajout des fichiers `docs/*-readme.md` décrivant les modules.
 
-uc0ehg-codex/2025-06-05
 ## [1.0.0] - 2025-05-27 "Genesis"
-=======
-## [1.0.0] - 2025-05-27 "Genesis"
-gomuxy-codex/2025-06-05
-
-# 📝 C2R OS - Journal des modifications
-main
-
-## [1.0.3] - 2025-06-06 "UI"
-
-### ✨ Interface
-- La barre latérale utilise un dégradé de gris avec une ombre portée pour un rendu cohérent en mode sombre et clair.
-
-## [1.0.2] - 2025-06-05 "UX"
-
-### ✨ Améliorations de l'interface
-- Alignement des icônes "installer" et "poubelle" à droite des tuiles du Store pour plus de cohérence.
-
-## [1.0.1] - 2025-06-05 "Docs"
-
-### 📄 Documentation
-- Ajout des fichiers `docs/*-readme.md` décrivant les modules.
-
-uc0ehg-codex/2025-06-05
-## [1.0.0] - 2025-05-27 "Genesis"
-=======
-## [1.0.0] - 2025-05-27 "Genesis"
-=======
-main
-main
 
 ### 🆕 Nouvelles fonctionnalités réelles implémentées
 
@@ -276,30 +242,11 @@ Documentation
 
 ## [1.0.3] - 2025-06-06 "UI"
 
-gomuxy-codex/2025-06-05
-### ✨ Améliorations de la sidebar
-uc0ehg-codex/2025-06-05
-- Le bouton de réduction est désormais intégré à la barre latérale et utilise une icône en chevron qui change de sens selon la position.
-- Le logo "C2R" n'est visible qu'en mode étendu de la barre.
-- Le bouton de réduction est désormais intégré à la barre latérale elle-même,
-  placé dans l'en-tête. Sa position s'adapte lorsque la barre passe à droite.
-
-## [1.0.4] - 2025-06-07 "UI"
-
-### ♻️ Navigation mobile simplifiée
-- Suppression du menu hamburger au profit de la barre de navigation basse.
-- Correction de la couleur bleue des icônes de désinstallation sur mobile.
-=======
-- Le bouton de réduction est désormais intégré à la barre latérale et utilise une icône en chevron qui change de sens selon la position.
-- Le logo "C2R" n'est visible qu'en mode étendu de la barre.
-=======
 ### ✨ Améliorations de la sidebar
 - Le bouton de réduction est désormais intégré à la barre latérale elle-même,
   placé dans l'en-tête. L'icône passe d'une croix à un petit carré selon l'état
   de la barre et sa position s'adapte lorsqu'elle est à droite.
-main
 
-0bhix5-codex/2025-06-05
 ## [1.0.4] - 2025-06-07 "UI"
 
 ### ♻️ Navigation mobile simplifiée
@@ -309,10 +256,3 @@ main
 
 ### 🐛 Correctifs
 - Les icônes "installer" et "poubelle" conservent leur design lors de la recherche ou du filtrage dans le Store.
-=======
-## [1.0.4] - 2025-06-07 "UI"
-
-### ♻️ Navigation mobile simplifiée
-- Suppression du menu hamburger au profit de la barre de navigation basse.
-main
-main

--- a/css/icons.css
+++ b/css/icons.css
@@ -181,6 +181,11 @@
     .nav-icon .icon {
         font-size: 1rem;
     }
+
+    /* Couleur rouge de la poubelle en mode mobile */
+    .app-toggle-btn.installed .icon {
+        color: var(--error-color) !important;
+    }
 }
 
 /* Thème sombre - ajustements spécifiques */

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -4,35 +4,6 @@ S'occupe du thème, de la navigation et des notifications. Il adapte l'interface
 
 Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, alignée à droite du texte. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile.
 
-gomuxy-codex/2025-06-05
-En mode mobile, la barre de navigation basse comprend un bouton **Applications**.
-L'icône correspondante est maintenant correctement chargée grâce à l'ajout de
-l'icône `list` dans `IconManager`.
-
-La page Profil intègre un tri visuel des applications installées via SortableJS.
-L'utilisateur peut glisser-déposer les tuiles pour définir son ordre préféré,
-qui est enregistré aussitôt.
-
-La sidebar propose également un mode compact activé par un bouton placé
-directement dans son en-tête. Celui-ci affiche une icône en chevron orientée
-suivant la position de la barre et n'affiche le logo "C2R" que lorsque la barre
-uc0ehg-codex/2025-06-05
-est ouverte. Ce bouton se situe en haut à droite ou à gauche suivant la position
-de la barre et permet d'afficher uniquement les icônes.
-=======
-est ouverte.
-main
-
-Le bouton hamburger a été retiré au profit de cette barre de navigation basse.
-
-La barre latérale bénéficie désormais d'un fond dégradé gris et d'une ombre pour s'intégrer harmonieusement aux thèmes sombre et clair.
-uc0ehg-codex/2025-06-05
-=======
-
-La sidebar propose également un mode compact activé par un bouton placé
-directement dans son en-tête. Ce bouton se situe en haut à droite ou à gauche
-suivant la position de la barre et permet d'afficher uniquement les icônes.
-=======
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 
 La page Profil permet de réordonner visuellement les applications installées grâce à SortableJS.
@@ -40,5 +11,3 @@ La page Profil permet de réordonner visuellement les applications installées g
 La sidebar propose un mode compact activé par un bouton dans son en-tête. L'icône passe d'une croix à un petit carré lorsque la barre est repliée, quelles que soient sa position et son thème.
 
 La barre latérale bénéficie d'un fond dégradé gris et d'une ombre pour s'intégrer harmonieusement aux thèmes sombre et clair. Le bouton hamburger a été supprimé au profit de cette barre de navigation basse.
-main
-main


### PR DESCRIPTION
## Summary
- fix style for mobile: ensure red uninstall icon
- restore Markdown docs after conflict markers cleanup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422300b038832e9f59ce502760fdc2