### PR TITLE
Fix conflits et poubelles rouges en mode compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,10 @@ Les icônes Font Awesome sont chargées via CDN. Le fichier `index.html` référ
 
 - Voir [`docs/icon-workflow.md`](docs/icon-workflow.md) pour le workflow complet des icônes.
 - La documentation de chaque module se trouve dans `docs/*-readme.md`.
-85811w-codex/2025-06-05
 - La liste des pop-ups indispensables figure dans [`docs/popup-readme.md`](docs/popup-readme.md).
 
 Le Store propose un bouton unique pour installer ou désinstaller une application. Les icônes restent alignées à droite et conservent leur couleur en mode sombre. Un bouton **Applications** apparaît sur mobile et les applications installées peuvent être réordonnées par glisser-déposer. Le filtre par type (applications, informations, services, formations) permet désormais de trier le catalogue.
-=======
-ptneoa-codex/2025-06-05
-- La liste des pop-ups indispensables figure dans
-  [`docs/popup-readme.md`](docs/popup-readme.md).
-=======
-main
+
 - Le Store propose un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge.
 - Les icônes d'installation sont alignées à droite des tuiles pour plus de clarté.
 - En mode sombre, la poubelle reste rouge et la taille des icônes est réduite pour le mobile.
@@ -24,7 +18,6 @@ main
 - Un bouton de déconnexion est disponible dans la page Profil.
 - La barre latérale intègre un bouton de réduction : l'icône passe d'une croix à un petit carré suivant l'état de la barre.
 - La barre latérale utilise un dégradé de gris et une ombre portée pour s'intégrer au thème.
-main
 
 ## Aperçu local
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,29 +1,3 @@
-85811w-codex/2025-06-05
-# 📝 C2R OS - Journal des modifications
-
-## [1.1.0] - 2025-06-06 "DragDrop"
-- Réorganisation des applications depuis la page Profil via glisser-déposer.
-- Ajout d'un filtre par type dans le Store (applications, informations, services, formations).
-
-## [1.0.5] - 2025-06-08 "Fix"
-- Les icônes du Store gardent leur design pendant la recherche.
-
-## [1.0.4] - 2025-06-07 "UI"
-- Suppression du menu hamburger au profit de la barre de navigation basse.
-- La barre latérale adopte un dégradé et peut se réduire.
-
-## [1.0.3] - 2025-06-06 "UI"
-- Amélioration générale de la sidebar.
-
-## [1.0.2] - 2025-06-05 "UX"
-- Alignement des icônes d'installation dans le Store.
-
-## [1.0.1] - 2025-06-05 "Docs"
-- Ajout des documents dans `docs/*-readme.md`.
-
-## [1.0.0] - 2025-05-27 "Genesis"
-- Première version publique.
-=======
 # 📝 C2R OS - Journal des modifications
 
 ## [1.1.0] - 2025-06-06 "DragDrop"
@@ -274,12 +248,6 @@ Documentation
   placé dans l'en-tête. L'icône passe d'une croix à un petit carré selon l'état
   de la barre et sa position s'adapte lorsqu'elle est à droite.
 
-ptneoa-codex/2025-06-05
-## [1.0.4] - 2025-06-07 "UI"
-
-### ♻️ Navigation mobile simplifiée
-- Suppression du menu hamburger au profit de la barre de navigation basse.
-=======
 ## [1.0.4] - 2025-06-07 "UI"
 
 ### ♻️ Navigation mobile simplifiée
@@ -289,5 +257,3 @@ ptneoa-codex/2025-06-05
 
 ### 🐛 Correctifs
 - Les icônes "installer" et "poubelle" conservent leur design lors de la recherche ou du filtrage dans le Store.
-main
-main

--- a/css/icons.css
+++ b/css/icons.css
@@ -63,6 +63,11 @@
     color: var(--error-color) !important;
 }
 
+/* Poubelle rouge en mode sidebar minimaliste */
+.minimal-sidebar .app-toggle-btn.installed .icon {
+    color: var(--error-color) !important;
+}
+
 /* Icônes de statut */
 .status-icon .icon {
     font-size: 1rem;

--- a/css/sidebar-minimal.css
+++ b/css/sidebar-minimal.css
@@ -275,7 +275,6 @@ body.minimal-sidebar .btn-logout:active {
 }
 
 /* Bouton de basculement */
-85811w-codex/2025-06-05
 .sidebar-toggle-minimal {
     position: absolute;
     top: 10px;
@@ -303,34 +302,6 @@ body.sidebar-right .sidebar .sidebar-toggle-minimal {
     background-color: var(--c2r-bg-hover);
     color: var(--c2r-text);
     transform: scale(1.1);
-=======
-.sidebar-toggle-minimal {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    background: none;
-    border: none;
-    border-radius: var(--c2r-radius);
-    padding: var(--c2r-spacing-sm);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    z-index: 1001;
-    transition: var(--c2r-transition);
-    color: var(--c2r-text-secondary);
-    font-size: 1rem;
-}
-
-body.sidebar-right .sidebar .sidebar-toggle-minimal {
-    right: auto;
-    left: 10px;
-}
-
-.sidebar-toggle-minimal:hover {
-    background-color: var(--c2r-bg-hover);
-    color: var(--c2r-text);
-main
 }
 
 /* Masquer sur mobile */

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -4,17 +4,10 @@ Gère le thème, la navigation et les notifications. Il adapte l'interface aux d
 
 Le Store utilise `toggleApp(appId)` pour installer ou désinstaller une application. L'icône d'installation devient une poubelle alignée à droite et conserve sa couleur en mode sombre. Sur mobile, un bouton **Applications** est présent dans la barre de navigation basse.
 
-85811w-codex/2025-06-05
-La page Profil permet de réordonner visuellement les applications grâce à SortableJS. La sidebar dispose d'un mode compact activé par un bouton dans son en-tête, affichant un chevron selon sa position.
-
-Le menu hamburger a été supprimé au profit de la barre de navigation basse et la sidebar bénéficie d'un fond dégradé avec une légère ombre pour s'intégrer aux deux thèmes.
-=======
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 
-La page Profil permet de réordonner visuellement les applications installées grâce à SortableJS.
-Un bouton de déconnexion est également présent sur cette page.
+La page Profil permet de réordonner visuellement les applications installées grâce à SortableJS. Un bouton de déconnexion est également présent sur cette page.
 
-La sidebar propose un mode compact activé par un bouton dans son en-tête. L'icône passe d'une croix à un petit carré lorsque la barre est repliée, quelles que soient sa position et son thème.
+La sidebar propose un mode compact activé par un bouton dans son en-tête. L'icône passe d'une croix à un petit carré lorsque la barre est repliée, quelles que soient sa position et son thème. Les icônes de suppression restent rouges comme en mode standard.
 
 La barre latérale bénéficie d'un fond dégradé gris et d'une ombre pour s'intégrer harmonieusement aux thèmes sombre et clair. Le bouton hamburger a été supprimé au profit de cette barre de navigation basse.
-main

--- a/index.html
+++ b/index.html
@@ -369,7 +369,6 @@
     <script src="js/modules/user/user-core.js"></script>
     <script src="js/modules/app/app-core.js"></script>
     <script src="js/modules/ui/ui-core.js"></script>
-85811w-codex/2025-06-05
     <script src="js/modules/profile/profile-system.js"></script>
     <script src="js/modules/system/system-integration.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
@@ -377,16 +376,6 @@
     <!-- Point d'entrée principal -->
     <!-- Correctif mobile pour le menu hamburger -->
     <script src="js/mobile-fix.js"></script>
-
-=======
-    <script src="js/modules/profile/profile-system.js"></script>
-    <script src="js/modules/system/system-integration.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-
-    <!-- Point d'entrée principal -->
-    <!-- Correctif mobile pour le menu hamburger -->
-    <script src="js/mobile-fix.js"></script>
-main
     <script src="js/sidebar-minimal.js"></script>
     <script src="js/bottom-nav.js"></script>
     <script>
@@ -400,19 +389,3 @@ main
     <script src="js/main.js"></script>
 </body>
 </html>
-85811w-codex/2025-06-05
-    <script src="js/sidebar-minimal.js"></script>
-    <script src="js/bottom-nav.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            IconManager.inject();
-        });
-        window.addEventListener('c2rosReady', () => {
-            IconManager.startAutoInject();
-        });
-    </script>
-    <script src="js/main.js"></script>
-</body>
-</html>
-=======
-main

--- a/js/sidebar-minimal.js
+++ b/js/sidebar-minimal.js
@@ -25,36 +25,20 @@ class SidebarMinimal {
         const sidebar = document.getElementById('sidebar');
         if (!sidebar) return;
 
-85811w-codex/2025-06-05
         const toggleBtn = document.createElement('button');
         toggleBtn.className = 'sidebar-toggle-minimal';
         toggleBtn.title = 'Basculer sidebar minimaliste';
         toggleBtn.setAttribute('aria-label', 'Basculer sidebar minimaliste');
-
-=======
-        const toggleBtn = document.createElement('button');
-        toggleBtn.className = 'sidebar-toggle-minimal';
-        toggleBtn.title = 'Basculer sidebar minimaliste';
-        toggleBtn.setAttribute('aria-label', 'Basculer sidebar minimaliste');
-
-main
         const icon = document.createElement('span');
         icon.className = 'nav-icon';
         toggleBtn.appendChild(icon);
         toggleBtn.addEventListener('click', () => {
             this.toggleMinimalSidebar();
         });
-85811w-codex/2025-06-05
 
         sidebar.appendChild(toggleBtn);
         this.updateToggleButtonIcon();
     }
-=======
-
-        sidebar.appendChild(toggleBtn);
-        this.updateToggleButtonIcon();
-    }
-main
     
     /**
      * Ajouter les tooltips aux éléments de navigation


### PR DESCRIPTION
## Notes
- suppression des marqueurs de conflit dans plusieurs fichiers
- ajout de la règle CSS pour garder les icônes de suppression rouges même en sidebar minimaliste
- mise à jour de la documentation après nettoyage

## Tests
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684228be90b8832ea39fbde75b38fe48