### PR TITLE
Fix red trash icon on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - Le Store propose un bouton unique pour installer ou désinstaller une application : l'icône « plus » devient une poubelle rouge.
 - Les icônes d'installation sont alignées à droite des tuiles pour plus de clarté.
 - En mode sombre, la poubelle reste rouge et la taille des icônes est réduite pour le mobile.
+- Correction: en mode mobile, la poubelle conserve bien sa couleur rouge.
 - En affichage mobile, un bouton **Applications** apparaît dans la barre de navigation basse.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un bouton de déconnexion est disponible dans la page Profil.

--- a/css/icons.css
+++ b/css/icons.css
@@ -63,6 +63,11 @@
     color: var(--error-color) !important;
 }
 
+/* Correction couleur poubelle sur mobile et desktop */
+.app-toggle-btn .fa-trash {
+    color: var(--error-color) !important;
+}
+
 /* Poubelle rouge en mode sidebar minimaliste */
 .minimal-sidebar .app-toggle-btn.installed .icon {
     color: var(--error-color) !important;

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -2,7 +2,7 @@
 
 S'occupe du thème, de la navigation et des notifications. Il adapte l'interface aux différents écrans et applique les préférences de l'utilisateur. C'est lui qui met à jour la sidebar et les pages lors des interactions.
 
-Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, alignée à droite du texte. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile.
+Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, alignée à droite du texte. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile. Une correction assure également que la poubelle reste rouge sur mobile.
 
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 


### PR DESCRIPTION
## Summary
- fix mobile trash icon color via CSS
- document fix in README and UI doc

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422e4af6c4832e97e1db5463e8e3d0