### PR TITLE
Fix Jest config and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,14 @@ Veillez à disposer de Python 3.
 
 ## Tests
 
-Pour exécuter les tests, lancez `npm test`.
+Avant de lancer les tests, installez les dépendances :
+
+```bash
+npm install
+```
+
+Vous pouvez ensuite exécuter les tests avec :
+
+```bash
+npm test
+```

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # 📝 C2R OS - Journal des modifications
 
+## [1.1.3] - 2025-06-09 "Tests"
+
+### ✅ Configuration Jest
+- Ajout du fichier `jest.config.cjs` pour centraliser la configuration des tests.
+- Mise à jour de `package.json` et de la documentation pour expliquer l'installation des dépendances avant l'exécution des tests.
+
+
 ## [1.1.2] - 2025-06-08 "WelcomeTiles"
 
 ### ✨ Page d'accueil

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  testMatch: ['**/tests/**/*.test.js']
+};

--- a/package.json
+++ b/package.json
@@ -7,8 +7,5 @@
   "devDependencies": {
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3"
-  },
-  "jest": {
-    "testEnvironment": "jsdom"
   }
 }


### PR DESCRIPTION
## Summary
- configure Jest via `jest.config.cjs`
- update README to document `npm install` before running tests
- update changelog with new entry about tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842aed026b0832ea24fed29c4dc3e01