### PR TITLE
Mise à jour formation ChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - Un bouton de déconnexion est disponible dans la page Profil.
 - La barre latérale intègre un bouton de réduction : l'icône passe d'une croix à un petit carré suivant l'état de la barre.
 - La barre latérale utilise un dégradé de gris et une ombre portée pour s'intégrer au thème.
-- Nouvelle application **Formation ChatGPT** : apprenez à exploiter ChatGPT grâce à des exemples interactifs et un quiz.
+- L'application **Formation ChatGPT** propose désormais un cours en dix pages avec navigation pour une prise en main intuitive.
 - La page d'accueil présente des tuiles explicatives pour découvrir le fonctionnement du site.
 
 ## Aperçu local

--- a/apps/chatgpt-training/app.css
+++ b/apps/chatgpt-training/app.css
@@ -9,8 +9,12 @@
 .training-app h2 {
     margin-bottom: 10px;
 }
-.course-section {
+.training-page {
+    display: none;
     margin-bottom: 20px;
+}
+.training-page.active {
+    display: block;
 }
 .quiz-section .question {
     margin-bottom: 15px;
@@ -22,4 +26,11 @@
 .quiz-result {
     margin-top: 10px;
     font-weight: bold;
+}
+.training-nav {
+    text-align: center;
+    margin-top: 20px;
+}
+.training-nav button {
+    margin: 0 10px;
 }

--- a/apps/chatgpt-training/app.html
+++ b/apps/chatgpt-training/app.html
@@ -1,23 +1,55 @@
 <div class="training-app">
     <h2><span data-icon="robot"></span> Formation ChatGPT</h2>
-    <p>Bienvenue dans cette formation interactive dédiée à l'utilisation de ChatGPT.</p>
 
-    <section class="course-section">
+    <div class="training-page active" data-page="1">
+        <p>Bienvenue dans cette formation interactive dédiée à l'utilisation de ChatGPT.</p>
+    </div>
+
+    <div class="training-page" data-page="2">
         <h3>1. Comprendre ChatGPT</h3>
         <p>ChatGPT est un assistant conversationnel capable de générer du texte en fonction de vos instructions. Plus votre demande est précise, plus la réponse sera pertinente.</p>
-    </section>
+    </div>
 
-    <section class="course-section">
-        <h3>2. Exemples d'utilisation</h3>
+    <div class="training-page" data-page="3">
+        <h3>2. Rédiger des prompts efficaces</h3>
+        <p>Formulez toujours votre demande avec un contexte clair et un objectif précis pour obtenir une réponse pertinente.</p>
+    </div>
+
+    <div class="training-page" data-page="4">
+        <h3>3. Exemples pour la rédaction</h3>
+        <p>Demandez la rédaction d'emails ou de textes courts en détaillant le ton souhaité.</p>
+    </div>
+
+    <div class="training-page" data-page="5">
+        <h3>4. Exemples pour l'analyse</h3>
+        <p>Fournissez un texte à résumer ou à analyser pour obtenir les points clés ou un style d'écriture.</p>
+    </div>
+
+    <div class="training-page" data-page="6">
+        <h3>5. Exemples pour le code</h3>
         <ul>
-            <li>Rédaction : <code>Rédige un email professionnel pour remercier un client</code></li>
-            <li>Analyse : <code>Résume-moi les points clés de ce texte</code></li>
-            <li>Code : <code>Écris une fonction JavaScript qui trie un tableau</code></li>
+            <li><code>Écris une fonction JavaScript qui trie un tableau</code></li>
+            <li><code>Montre-moi un exemple d'appel API en Python</code></li>
         </ul>
-    </section>
+    </div>
 
-    <section class="quiz-section">
-        <h3>3. Quiz de fin</h3>
+    <div class="training-page" data-page="7">
+        <h3>6. Bonnes pratiques</h3>
+        <p>Structurez vos questions, précisez le format attendu et n'hésitez pas à poser des questions de suivi.</p>
+    </div>
+
+    <div class="training-page" data-page="8">
+        <h3>7. Personnalisation des réponses</h3>
+        <p>Indiquez le public ciblé ou le niveau de langage souhaité pour adapter les réponses.</p>
+    </div>
+
+    <div class="training-page" data-page="9">
+        <h3>8. Résumé</h3>
+        <p>En combinant contexte, exemples et questions de suivi, vous optimisez la qualité des réponses de ChatGPT.</p>
+    </div>
+
+    <div class="training-page" data-page="10">
+        <h3>9. Quiz final</h3>
         <form id="quiz-form">
             <div class="question">
                 <p>1. Quelle est la meilleure façon de formuler un prompt&nbsp;?</p>
@@ -37,5 +69,10 @@
             <button type="button" onclick="submitQuiz()">Valider</button>
         </form>
         <div id="quiz-result" class="quiz-result"></div>
-    </section>
+    </div>
+
+    <div class="training-nav">
+        <button id="prevBtn" onclick="changePage(-1)" disabled>Précédent</button>
+        <button id="nextBtn" onclick="changePage(1)">Suivant</button>
+    </div>
 </div>

--- a/apps/chatgpt-training/app.js
+++ b/apps/chatgpt-training/app.js
@@ -1,6 +1,25 @@
 // Formation ChatGPT pour C2R OS
+let currentPage = 1;
+
+function showPage(page) {
+    const pages = document.querySelectorAll('.training-page');
+    if (page < 1 || page > pages.length) return;
+    pages.forEach(p => p.classList.remove('active'));
+    pages[page - 1].classList.add('active');
+    currentPage = page;
+    const prevBtn = document.getElementById('prevBtn');
+    const nextBtn = document.getElementById('nextBtn');
+    if (prevBtn) prevBtn.disabled = page === 1;
+    if (nextBtn) nextBtn.disabled = page === pages.length;
+}
+
+function changePage(delta) {
+    showPage(currentPage + delta);
+}
+
 function initChatGPTTraining() {
     console.log('🚀 Formation ChatGPT initialisée');
+    showPage(1);
 }
 
 function submitQuiz() {
@@ -19,3 +38,4 @@ function submitQuiz() {
 
 window.initChatGPTTraining = initChatGPTTraining;
 window.submitQuiz = submitQuiz;
+window.changePage = changePage;

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # 📝 C2R OS - Journal des modifications
 
+## [1.1.4] - 2025-06-10 "TrainingUI"
+
+### 📚 Formation
+- La formation ChatGPT est désormais découpée en dix pages avec navigation intuitive.
+
 ## [1.1.3] - 2025-06-09 "Tests"
 
 ### ✅ Configuration Jest

--- a/docs/app-readme.md
+++ b/docs/app-readme.md
@@ -6,4 +6,4 @@ Le module est utilisé par `UICore.toggleApp()` pour installer ou désinstaller 
 
 Depuis la version 1.1.0, chaque application possède un type (application, information, service ou formation) afin de faciliter le filtrage dans le Store.
 
-La formation **ChatGPT** fait partie des applications intégrées. Elle illustre comment rédiger de bons prompts et propose un quiz interactif.
+La formation **ChatGPT** fait partie des applications intégrées. Elle présente désormais un cours en dix pages avec quiz final pour apprendre à rédiger de bons prompts.

--- a/docs/chatgpt-training-readme.md
+++ b/docs/chatgpt-training-readme.md
@@ -1,11 +1,17 @@
 # Formation ChatGPT
 
-Cette application propose un mini-cours pour comprendre et exploiter efficacement ChatGPT. Elle inclut des explications, des exemples d'utilisation et un quiz final pour valider vos connaissances.
+Cette application propose un mini-cours pour comprendre et exploiter efficacement ChatGPT. Depuis la version 1.1.4, la formation est découpée en **dix pages** interactives pour guider l'utilisateur pas à pas.
 
 ## Contenu
-- Présentation rapide de ChatGPT et de son fonctionnement
-- Bonnes pratiques pour rédiger des prompts clairs
-- Exemples concrets pour la rédaction, l'analyse et le code
-- Quiz de trois questions avec correction immédiate
+- Introduction générale
+- Comprendre ChatGPT et son fonctionnement
+- Rédiger des prompts clairs
+- Exemples pour la rédaction
+- Exemples pour l'analyse de texte
+- Exemples pour le code
+- Bonnes pratiques et limites
+- Personnalisation des réponses
+- Résumé complet
+- Quiz final de trois questions avec correction immédiate
 
-L'application est classée comme type *formation* dans le Store.
+La navigation « Précédent »/« Suivant » rend le parcours plus intuitif. L'application est classée comme type *formation* dans le Store.


### PR DESCRIPTION
## Résumé
- restructure l'application `chatgpt-training` en dix pages avec navigation
- ajoute la logique de changement de page et met à jour le style
- précise dans la documentation et le changelog l'ajout des dix pages

## Tests
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842cecbff94832e913f4b5a9892a428