### PR TITLE
Fix color of mobile close button

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - En mode sombre, la poubelle reste rouge et la taille des icônes est réduite pour le mobile.
 - Correction: en mode mobile, la poubelle conserve bien sa couleur rouge.
 - En affichage mobile, un bouton **Applications** apparaît dans la barre de navigation basse.
+- La croix du menu mobile adopte la même couleur neutre que les autres boutons.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un bouton de déconnexion est disponible dans la page Profil.
 - La barre latérale intègre un bouton de réduction : l'icône passe d'une croix à un petit carré suivant l'état de la barre.

--- a/changelog.md
+++ b/changelog.md
@@ -279,3 +279,8 @@ Documentation
 
 ### 🐛 Correctifs
 - Les icônes "installer" et "poubelle" conservent leur design lors de la recherche ou du filtrage dans le Store.
+
+## [1.0.6] - 2025-06-09 "Fix"
+
+### 🐛 Correctifs
+- La poubelle du Store et la croix de fermeture du menu mobile n'apparaissent plus en bleu.

--- a/css/bottom-nav.css
+++ b/css/bottom-nav.css
@@ -69,6 +69,20 @@
     border-bottom: 1px solid var(--c2r-border);
 }
 
+/* Bouton de fermeture du menu mobile */
+.close-btn {
+    background: none;
+    border: none;
+    color: var(--c2r-text-muted);
+    font-size: 24px;
+    cursor: pointer;
+    padding: 0;
+}
+
+.close-btn:hover {
+    color: var(--c2r-text);
+}
+
 .mobile-apps-list {
     padding: var(--c2r-spacing-md);
 }

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -3,6 +3,7 @@
 S'occupe du thème, de la navigation et des notifications. Il adapte l'interface aux différents écrans et applique les préférences de l'utilisateur. C'est lui qui met à jour la sidebar et les pages lors des interactions.
 
 Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, alignée à droite du texte. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile. Une correction assure également que la poubelle reste rouge sur mobile.
+La petite croix fermant la liste déroulante des applications sur mobile adopte elle aussi une teinte neutre afin d'éviter tout affichage bleu.
 
 En mode mobile, la barre de navigation basse comprend un bouton **Applications**. L'icône est chargée grâce à l'ajout du pictogramme `list` dans `IconManager`.
 


### PR DESCRIPTION
## Summary
- style the close button in the mobile dropdown
- describe the fix in the docs and README
- add note in the changelog

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d2210e18832eb2a7fcba40cc51d5