### PR TITLE
feat: option globale pour désactiver les pop-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Les icônes Font Awesome sont chargées via CDN. Le fichier `index.html` référ
 
 - Voir [`docs/icon-workflow.md`](docs/icon-workflow.md) pour le workflow complet des icônes.
 - La documentation de chaque module se trouve dans `docs/*-readme.md`.
-- La liste des pop-ups indispensables figure dans [`docs/popup-readme.md`](docs/popup-readme.md).
+- Les pop-ups de confirmation peuvent être désactivés via `confirmDialogs` dans `js/modules/core/config.js`. Voir [`docs/popup-readme.md`](docs/popup-readme.md) pour la procédure détaillée et les risques.
 
 Le Store propose un bouton unique pour installer ou désinstaller une application. Les icônes restent alignées à droite et conservent leur couleur en mode sombre. Un bouton **Applications** apparaît sur mobile et les applications installées peuvent être réordonnées par glisser-déposer. Le filtre par type (applications, informations, services, formations) permet désormais de trier le catalogue.
 

--- a/apps/notepad/app.js
+++ b/apps/notepad/app.js
@@ -175,7 +175,7 @@ function startRealTimeUpdates() {
  */
 function createNewNote() {
     if (notepadApp.isModified && notepadApp.editor.value.trim()) {
-        if (!confirm('Le document actuel a été modifié. Voulez-vous continuer sans sauvegarder ?')) {
+        if (!c2rConfirm('Le document actuel a été modifié. Voulez-vous continuer sans sauvegarder ?')) {
             return;
         }
     }
@@ -322,7 +322,7 @@ function previewFile(filename) {
  * Supprimer un fichier
  */
 function deleteFile(filename) {
-    if (confirm(`Êtes-vous sûr de vouloir supprimer "${filename}" ?`)) {
+    if (c2rConfirm(`Êtes-vous sûr de vouloir supprimer "${filename}" ?`)) {
         notepadApp.files = notepadApp.files.filter(f => f.name !== filename);
         saveFilesToStorage();
         renderFileList();
@@ -343,7 +343,7 @@ function confirmFileAction() {
     const file = notepadApp.files.find(f => f.name === filename);
     if (file) {
         // Charger le fichier
-        if (notepadApp.isModified && !confirm('Le document actuel a été modifié. Continuer ?')) {
+        if (notepadApp.isModified && !c2rConfirm('Le document actuel a été modifié. Continuer ?')) {
             return;
         }
         

--- a/apps/todolist/app.js
+++ b/apps/todolist/app.js
@@ -196,7 +196,7 @@ function deleteTask(taskId) {
     const task = todoApp.tasks.find(t => t.id === taskId);
     if (!task) return;
     
-    if (confirm(`Êtes-vous sûr de vouloir supprimer "${task.text}" ?`)) {
+    if (c2rConfirm(`Êtes-vous sûr de vouloir supprimer "${task.text}" ?`)) {
         todoApp.tasks = todoApp.tasks.filter(t => t.id !== taskId);
         
         saveTasksToStorage();
@@ -254,7 +254,7 @@ function clearCompletedTasks() {
         return;
     }
     
-    if (confirm(`Supprimer ${completedCount} tâche(s) terminée(s) ?`)) {
+    if (c2rConfirm(`Supprimer ${completedCount} tâche(s) terminée(s) ?`)) {
         todoApp.tasks = todoApp.tasks.filter(t => !t.completed);
         
         saveTasksToStorage();

--- a/docs/popup-readme.md
+++ b/docs/popup-readme.md
@@ -1,7 +1,28 @@
 # Pop-ups essentiels
 
-Cette documentation recense les fenêtres de confirmation ou modales jugées indispensables ou très utiles dans le projet.
+Cette documentation listait les fenêtres de confirmation utilisées pour protéger les actions sensibles.
 
 - **Réinitialisation complète du système** : double confirmation nécessaire pour éviter toute perte de données.
 - **Suppression d'un utilisateur** : empêche l'effacement irréversible d'un compte par erreur.
 - **Ouverture de la fenêtre d'authentification** : étape obligatoire pour se connecter ou créer un compte.
+
+## Suppression des pop-ups d'action
+
+Certaines installations souhaitent supprimer ces dialogues afin d'accélérer les opérations.
+
+### Désactivation via la configuration
+
+Dans `js/modules/core/config.js`, passez `confirmDialogs` à `false` dans la section `ui`.
+Toutes les fonctions de confirmation utilisent désormais `c2rConfirm()`, qui respecte ce paramètre.
+
+### Suppression manuelle
+
+1. Rechercher dans le code les appels à `c2rConfirm()` ou aux modales.
+2. Supprimer ces appels ou les remplacer par des notifications non bloquantes.
+3. Tester chaque fonction impactée pour éviter toute suppression accidentelle de données.
+
+### Conséquences
+
+En supprimant les confirmations, les actions critiques (réinitialisation, suppression d'utilisateur, fermeture sans sauvegarde) seront exécutées immédiatement. Cela augmente le risque d'erreurs involontaires et de perte de données.
+
+Il est conseillé de conserver une sauvegarde des données ou de restreindre l'accès aux fonctions sensibles si les pop-ups sont désactivés.

--- a/js/main.js
+++ b/js/main.js
@@ -293,7 +293,7 @@ window.handleAppUninstall = function(appId) {
     const app = appCore.getApp(appId);
     if (!app) return;
     
-    if (confirm(`Êtes-vous sûr de vouloir désinstaller ${app.name} ?`)) {
+    if (c2rConfirm(`Êtes-vous sûr de vouloir désinstaller ${app.name} ?`)) {
         if (appCore.uninstallApp(appId)) {
             uiCore.showNotification(`${IconManager.getIcon('uninstall')} ${app.name} désinstallée`, 'info');
             uiCore.refreshApplicationsList();
@@ -335,8 +335,8 @@ function handleSystemReset() {
         return;
     }
     
-    if (confirm('⚠️ Cette action va réinitialiser complètement le système. Continuer ?')) {
-        if (confirm('🚨 ATTENTION: Toutes les données seront perdues. Êtes-vous absolument certain ?')) {
+    if (c2rConfirm('⚠️ Cette action va réinitialiser complètement le système. Continuer ?')) {
+        if (c2rConfirm('🚨 ATTENTION: Toutes les données seront perdues. Êtes-vous absolument certain ?')) {
             uiCore?.showNotification(`${IconManager.getIcon('refresh')} Réinitialisation du système en cours...`, 'warning');
             
             setTimeout(() => {
@@ -753,7 +753,7 @@ function handleLogout() {
     
     if (!userCore || !uiCore) return;
     
-    if (confirm('Êtes-vous sûr de vouloir vous déconnecter ?')) {
+    if (c2rConfirm('Êtes-vous sûr de vouloir vous déconnecter ?')) {
         userCore.logout();
         uiCore.showNotification(`${IconManager.getIcon('signout')} Déconnexion réussie`, 'info');
         

--- a/js/modules/core/config.js
+++ b/js/modules/core/config.js
@@ -63,7 +63,8 @@ class CoreConfig {
             animationDuration: 300,
             notificationTimeout: 3000,
             responsiveBreakpoint: 768,
-            maxNotifications: 5
+            maxNotifications: 5,
+            confirmDialogs: true
         };
         
         // Stockage local
@@ -209,3 +210,12 @@ window.CoreConfig = CoreConfig;
 
 // Instance globale
 window.C2R_CONFIG = new CoreConfig();
+
+// Fonction de confirmation centralisee
+window.c2rConfirm = function(message) {
+    const cfg = window.C2R_CONFIG?.ui;
+    if (cfg && cfg.confirmDialogs === false) {
+        return true;
+    }
+    return confirm(message);
+};

--- a/js/modules/ui/ui-core.js
+++ b/js/modules/ui/ui-core.js
@@ -457,7 +457,7 @@ class UICore {
             
             if (user) {
                 const newRole = user.role === 'admin' ? 'user' : 'admin';
-                if (confirm(`Changer le rôle de ${user.email} vers ${newRole} ?`)) {
+                if (c2rConfirm(`Changer le rôle de ${user.email} vers ${newRole} ?`)) {
                     user.role = newRole;
                     userCore.saveUsers();
                     this.refreshAdminPanel();
@@ -482,7 +482,7 @@ class UICore {
             const users = userCore.getAllUsers();
             const user = users.find(u => u.id === userId);
             
-            if (user && confirm(`Êtes-vous sûr de vouloir supprimer l'utilisateur ${user.email} ?`)) {
+            if (user && c2rConfirm(`Êtes-vous sûr de vouloir supprimer l'utilisateur ${user.email} ?`)) {
                 if (userCore.deleteUser(userId)) {
                     this.refreshAdminPanel();
                     this.showNotification(`Utilisateur ${user.email} supprimé`, 'warning');
@@ -537,7 +537,7 @@ class UICore {
      * Gérer la déconnexion
      */
     handleLogout() {
-        if (confirm('Êtes-vous sûr de vouloir vous déconnecter ?')) {
+        if (c2rConfirm('Êtes-vous sûr de vouloir vous déconnecter ?')) {
             const userCore = window.C2R_SYSTEM?.userCore;
             if (userCore) {
                 userCore.logout();


### PR DESCRIPTION
## Summary
- ajouter un paramètre `confirmDialogs` dans la configuration
- centraliser la confirmation via `c2rConfirm`
- remplacer tous les `confirm()` par `c2rConfirm()`
- documenter la désactivation dans `docs/popup-readme.md`
- préciser l'option dans le README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68422cb215c4832eb68f8c989180b804