### PR TITLE
Ajout support PWA mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - Un bouton de déconnexion est disponible dans la page Profil.
 - La barre latérale intègre un bouton de réduction : l'icône passe d'une croix à un petit carré suivant l'état de la barre.
 - La barre latérale utilise un dégradé de gris et une ombre portée pour s'intégrer au thème.
+ - Grâce à un manifeste web sans icônes binaires et aux meta tags dédiés, le site peut être installé sur mobile en plein écran.
 - L'application **Formation ChatGPT** propose désormais un cours en dix pages avec navigation pour une prise en main intuitive.
 - La page d'accueil présente des tuiles explicatives pour découvrir le fonctionnement du site.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,17 @@
 # 📝 C2R OS - Journal des modifications
 
+## [1.1.6] - 2025-06-11 "PWAfix"
+
+### 🗑️ Nettoyage
+- Suppression des icônes binaires du manifeste mobile pour alléger le dépôt.
+- Le manifeste reste présent pour permettre un affichage plein écran sur mobile.
+
+## [1.1.5] - 2025-06-11 "PWA"
+
+### 📱 Support mobile
+- Ajout d'un fichier `manifest.json` et des meta tags pour installer l'OS sur mobile.
+- Une fois installé, la barre du navigateur se masque pour un affichage plein écran.
+
 ## [1.1.4] - 2025-06-10 "TrainingUI"
 
 ### 📚 Formation

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -11,3 +11,4 @@ La page Profil permet de réordonner visuellement les applications installées g
 La sidebar propose un mode compact activé par un bouton dans son en-tête. L'icône passe d'une croix à un petit carré lorsque la barre est repliée, quelles que soient sa position et son thème. Les icônes de suppression restent rouges comme en mode standard.
 
 La barre latérale bénéficie d'un fond dégradé gris et d'une ombre pour s'intégrer harmonieusement aux thèmes sombre et clair. Le bouton hamburger a été supprimé au profit de cette barre de navigation basse.
+Depuis la version 1.1.6, un fichier `manifest.json` sans icônes binaires et des meta tags permettent d'installer C2R OS sur mobile en plein écran.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="theme-color" content="#181818">
+    <link rel="manifest" href="manifest.json">
     <title>C2R OS - Système Modulaire</title>
     <link rel="stylesheet" href="css/reset.css">
     <link rel="stylesheet" href="css/global.css">

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "C2R OS",
+  "short_name": "C2R",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#181818",
+  "theme_color": "#181818"
+}

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.1.0",
-  "build": "2025-05-27",
+  "version": "1.1.6",
+  "build": "2025-06-11",
   "codename": "Genesis",
   "description": "Premier déploiement du système C2R OS",
   "core_modules": [


### PR DESCRIPTION
## Notes
- retrait des icônes PNG du manifeste pour éviter les fichiers binaires
- mise à jour de la documentation et du changelog
- la version passe en **1.1.6**

## Tests
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842d0d6c584832ea5553335b93a3ed2