### PR TITLE
Ajout d’un test de confirmation des fenêtres

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,13 +12,11 @@ pdin0i-codex/2025-06-06
 ### 📱 Support mobile
 - Ajout d'un fichier `manifest.json` et des meta tags pour installer l'OS sur mobile.
 - Une fois installé, la barre du navigateur se masque pour un affichage plein écran.
-=======
 ## [1.1.5] - 2025-06-11 "UI Icons"
 
 ### ✨ Harmonisation des icônes
 - Les applications utilisent désormais les pictogrammes Font Awesome au lieu des emojis.
 - Mise à jour du gestionnaire d'icônes avec de nouveaux glyphes (table, bars, code, chart).
-main
 
 ## [1.1.4] - 2025-06-10 "TrainingUI"
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "c2ros",
   "version": "1.0.0",
   "scripts": {
-    "test": "jest"
+    "test": "jest --config jest.config.cjs"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/tests/confirm-dialogs.test.js
+++ b/tests/confirm-dialogs.test.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('c2rConfirm', () => {
+  beforeAll(() => {
+    const script = fs.readFileSync(path.resolve(__dirname, '../js/modules/core/config.js'), 'utf8');
+    window.eval(script);
+  });
+
+  test('retourne toujours true lorsque confirmDialogs est false', () => {
+    window.C2R_CONFIG.ui.confirmDialogs = false;
+    window.confirm = jest.fn(() => false);
+    const result = window.c2rConfirm('Continuer ?');
+    expect(result).toBe(true);
+    expect(window.confirm).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Notes
Aucun point supplémentaire.

## Résumé
- mise à jour de `package.json` pour cibler explicitement `jest.config.cjs`
- correction du `changelog` en retirant les délimiteurs de conflit
- ajout du test `confirm-dialogs` pour vérifier `c2rConfirm`

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68430e2b8ff4832ebdc2bc9d87aa1f3a