### PR TITLE
Fix confirm dialog persistence and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,9 @@ Les icônes Font Awesome sont chargées via CDN. Le fichier `index.html` référ
 
 - Voir [`docs/icon-workflow.md`](docs/icon-workflow.md) pour le workflow complet des icônes.
 - La documentation de chaque module se trouve dans `docs/*-readme.md`.
-8er4ce-codex/2025-06-06
 - Les pop-ups de confirmation peuvent être désactivés via `confirmDialogs` dans `js/modules/core/config.js` ou depuis le profil utilisateur grâce à une tuile dédiée. Voir [`docs/popup-readme.md`](docs/popup-readme.md) pour la procédure détaillée et les risques.
-=======
 - La liste des pop-ups indispensables figure dans [`docs/popup-readme.md`](docs/popup-readme.md).
 - Les informations de support sont détaillées dans [`docs/contact-readme.md`](docs/contact-readme.md).
-main
 
 Le Store propose un bouton unique pour installer ou désinstaller une application. Les icônes restent alignées à droite et conservent leur couleur en mode sombre. Un bouton **Applications** apparaît sur mobile et les applications installées peuvent être réordonnées par glisser-déposer. Le filtre par type (applications, informations, services, formations) permet désormais de trier le catalogue.
 
@@ -25,15 +22,12 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - Un bouton de déconnexion est disponible dans la page Profil.
 - La barre latérale intègre un bouton de réduction : l'icône passe d'une croix à un petit carré suivant l'état de la barre.
 - La barre latérale utilise un dégradé de gris et une ombre portée pour s'intégrer au thème.
-gud95h-codex/2025-06-06
 - Nouvelle application **Formation ChatGPT** : apprenez à exploiter ChatGPT grâce à des exemples interactifs et un quiz.
 - Une page **Contact** fait son apparition pour joindre l'équipe de développement par mail ou téléphone.
-=======
- - Grâce à un manifeste web sans icônes binaires et aux meta tags dédiés, le site peut être installé sur mobile en plein écran.
+- Grâce à un manifeste web sans icônes binaires et aux meta tags dédiés, le site peut être installé sur mobile en plein écran.
 - L'application **Formation ChatGPT** propose désormais un cours en dix pages avec navigation pour une prise en main intuitive.
 - La page d'accueil présente des tuiles explicatives pour découvrir le fonctionnement du site.
 - Les applications internes utilisent désormais uniquement les icônes Font Awesome pour un style unifié.
-main
 
 ## Aperçu local
 

--- a/docs/popup-readme.md
+++ b/docs/popup-readme.md
@@ -13,7 +13,7 @@ Certaines installations souhaitent supprimer ces dialogues afin d'accélérer le
 ### Désactivation via la configuration
 
 Dans `js/modules/core/config.js`, passez `confirmDialogs` à `false` dans la section `ui` ou utilisez la tuile "Pop-ups de confirmation" du profil utilisateur.
-Toutes les fonctions de confirmation utilisent désormais `c2rConfirm()`, qui respecte ce paramètre.
+Toutes les fonctions de confirmation utilisent désormais `c2rConfirm()`, qui respecte ce paramètre. La désactivation est enregistrée pour la session et rechargée automatiquement au démarrage suivant.
 
 ### Suppression manuelle
 

--- a/js/modules/ui/ui-core.js
+++ b/js/modules/ui/ui-core.js
@@ -106,6 +106,7 @@ class UICore {
             
             if (preferences) {
                 this.applyPreferences(preferences);
+                this.config.save();
             }
         }
     }
@@ -885,6 +886,7 @@ class UICore {
      */
     setConfirmDialogs(enabled) {
         this.config.ui.confirmDialogs = enabled;
+        this.config.save();
     }
     
     /**


### PR DESCRIPTION
## Summary
- persist confirm dialogs setting in `setConfirmDialogs`
- save config after loading user preferences
- clarify confirm dialog persistence in docs
- clean merge markers from README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68430e2a8254832e87614d6e01a2a53f