### PR TITLE
Persist confirm dialog preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Les icônes Font Awesome sont chargées via CDN. Le fichier `index.html` référ
 
 - Voir [`docs/icon-workflow.md`](docs/icon-workflow.md) pour le workflow complet des icônes.
 - La documentation de chaque module se trouve dans `docs/*-readme.md`.
-- La liste des pop-ups indispensables figure dans [`docs/popup-readme.md`](docs/popup-readme.md).
+ - Les pop-ups de confirmation peuvent être désactivés via `confirmDialogs` dans `js/modules/core/config.js` ou depuis le profil utilisateur grâce à une tuile dédiée. La préférence est sauvegardée et restaurée au prochain démarrage. Voir [`docs/popup-readme.md`](docs/popup-readme.md) pour la procédure détaillée et les risques.
 
 Le Store propose un bouton unique pour installer ou désinstaller une application. Les icônes restent alignées à droite et conservent leur couleur en mode sombre. Un bouton **Applications** apparaît sur mobile et les applications installées peuvent être réordonnées par glisser-déposer. Le filtre par type (applications, informations, services, formations) permet désormais de trier le catalogue.
 

--- a/apps/notepad/app.js
+++ b/apps/notepad/app.js
@@ -175,7 +175,7 @@ function startRealTimeUpdates() {
  */
 function createNewNote() {
     if (notepadApp.isModified && notepadApp.editor.value.trim()) {
-        if (!confirm('Le document actuel a été modifié. Voulez-vous continuer sans sauvegarder ?')) {
+        if (!c2rConfirm('Le document actuel a été modifié. Voulez-vous continuer sans sauvegarder ?')) {
             return;
         }
     }
@@ -322,7 +322,7 @@ function previewFile(filename) {
  * Supprimer un fichier
  */
 function deleteFile(filename) {
-    if (confirm(`Êtes-vous sûr de vouloir supprimer "${filename}" ?`)) {
+    if (c2rConfirm(`Êtes-vous sûr de vouloir supprimer "${filename}" ?`)) {
         notepadApp.files = notepadApp.files.filter(f => f.name !== filename);
         saveFilesToStorage();
         renderFileList();
@@ -343,7 +343,7 @@ function confirmFileAction() {
     const file = notepadApp.files.find(f => f.name === filename);
     if (file) {
         // Charger le fichier
-        if (notepadApp.isModified && !confirm('Le document actuel a été modifié. Continuer ?')) {
+        if (notepadApp.isModified && !c2rConfirm('Le document actuel a été modifié. Continuer ?')) {
             return;
         }
         

--- a/apps/todolist/app.js
+++ b/apps/todolist/app.js
@@ -196,7 +196,7 @@ function deleteTask(taskId) {
     const task = todoApp.tasks.find(t => t.id === taskId);
     if (!task) return;
     
-    if (confirm(`Êtes-vous sûr de vouloir supprimer "${task.text}" ?`)) {
+    if (c2rConfirm(`Êtes-vous sûr de vouloir supprimer "${task.text}" ?`)) {
         todoApp.tasks = todoApp.tasks.filter(t => t.id !== taskId);
         
         saveTasksToStorage();
@@ -254,7 +254,7 @@ function clearCompletedTasks() {
         return;
     }
     
-    if (confirm(`Supprimer ${completedCount} tâche(s) terminée(s) ?`)) {
+    if (c2rConfirm(`Supprimer ${completedCount} tâche(s) terminée(s) ?`)) {
         todoApp.tasks = todoApp.tasks.filter(t => !t.completed);
         
         saveTasksToStorage();

--- a/docs/popup-readme.md
+++ b/docs/popup-readme.md
@@ -1,7 +1,29 @@
 # Pop-ups essentiels
 
-Cette documentation recense les fenêtres de confirmation ou modales jugées indispensables ou très utiles dans le projet.
+Cette documentation listait les fenêtres de confirmation utilisées pour protéger les actions sensibles.
 
 - **Réinitialisation complète du système** : double confirmation nécessaire pour éviter toute perte de données.
 - **Suppression d'un utilisateur** : empêche l'effacement irréversible d'un compte par erreur.
 - **Ouverture de la fenêtre d'authentification** : étape obligatoire pour se connecter ou créer un compte.
+
+## Suppression des pop-ups d'action
+
+Certaines installations souhaitent supprimer ces dialogues afin d'accélérer les opérations.
+
+### Désactivation via la configuration
+
+Dans `js/modules/core/config.js`, passez `confirmDialogs` à `false` dans la section `ui` ou utilisez la tuile "Pop-ups de confirmation" du profil utilisateur.
+Toutes les fonctions de confirmation utilisent désormais `c2rConfirm()`, qui respecte ce paramètre.
+La désactivation est enregistrée dans la configuration et sera automatiquement réappliquée au prochain chargement.
+
+### Suppression manuelle
+
+1. Rechercher dans le code les appels à `c2rConfirm()` ou aux modales.
+2. Supprimer ces appels ou les remplacer par des notifications non bloquantes.
+3. Tester chaque fonction impactée pour éviter toute suppression accidentelle de données.
+
+### Conséquences
+
+En supprimant les confirmations, les actions critiques (réinitialisation, suppression d'utilisateur, fermeture sans sauvegarde) seront exécutées immédiatement. Cela augmente le risque d'erreurs involontaires et de perte de données.
+
+Il est conseillé de conserver une sauvegarde des données ou de restreindre l'accès aux fonctions sensibles si les pop-ups sont désactivés.

--- a/docs/profile-readme.md
+++ b/docs/profile-readme.md
@@ -11,3 +11,5 @@ mobile se mettent automatiquement à jour pour refléter ce nouvel ordre. Lors d
 déplacement, l'application en cours de glisse est légèrement agrandie et son
 fond s'assombrit pour mieux la distinguer.
 Un bouton de déconnexion est disponible pour terminer la session.
+
+La section Préférences comporte plusieurs interrupteurs dont un pour activer ou non les pop-ups de confirmation. Lorsque l'option est désactivée, la configuration est mémorisée pour les prochaines sessions.

--- a/index.html
+++ b/index.html
@@ -187,6 +187,16 @@
                         </label>
                     </div>
 
+                    <div class="preference-group">
+                        <label class="switch-label">
+                            <span>Pop-ups de confirmation</span>
+                            <label class="switch">
+                                <input type="checkbox" id="confirm-dialogs-toggle" checked>
+                                <span class="slider"></span>
+                            </label>
+                        </label>
+                    </div>
+
                     <button class="btn btn-secondary" id="clear-cache-user" aria-label="Vider le cache">
                         Vider le cache
                     </button>

--- a/js/main.js
+++ b/js/main.js
@@ -293,7 +293,7 @@ window.handleAppUninstall = function(appId) {
     const app = appCore.getApp(appId);
     if (!app) return;
     
-    if (confirm(`Êtes-vous sûr de vouloir désinstaller ${app.name} ?`)) {
+    if (c2rConfirm(`Êtes-vous sûr de vouloir désinstaller ${app.name} ?`)) {
         if (appCore.uninstallApp(appId)) {
             uiCore.showNotification(`${IconManager.getIcon('uninstall')} ${app.name} désinstallée`, 'info');
             uiCore.refreshApplicationsList();
@@ -335,8 +335,8 @@ function handleSystemReset() {
         return;
     }
     
-    if (confirm('⚠️ Cette action va réinitialiser complètement le système. Continuer ?')) {
-        if (confirm('🚨 ATTENTION: Toutes les données seront perdues. Êtes-vous absolument certain ?')) {
+    if (c2rConfirm('⚠️ Cette action va réinitialiser complètement le système. Continuer ?')) {
+        if (c2rConfirm('🚨 ATTENTION: Toutes les données seront perdues. Êtes-vous absolument certain ?')) {
             uiCore?.showNotification(`${IconManager.getIcon('refresh')} Réinitialisation du système en cours...`, 'warning');
             
             setTimeout(() => {
@@ -753,7 +753,7 @@ function handleLogout() {
     
     if (!userCore || !uiCore) return;
     
-    if (confirm('Êtes-vous sûr de vouloir vous déconnecter ?')) {
+    if (c2rConfirm('Êtes-vous sûr de vouloir vous déconnecter ?')) {
         userCore.logout();
         uiCore.showNotification(`${IconManager.getIcon('signout')} Déconnexion réussie`, 'info');
         

--- a/js/modules/core/config.js
+++ b/js/modules/core/config.js
@@ -63,7 +63,8 @@ class CoreConfig {
             animationDuration: 300,
             notificationTimeout: 3000,
             responsiveBreakpoint: 768,
-            maxNotifications: 5
+            maxNotifications: 5,
+            confirmDialogs: true
         };
         
         // Stockage local
@@ -178,7 +179,8 @@ class CoreConfig {
     reset() {
         localStorage.removeItem(`${this.storage.prefix}config`);
         // Recharger les valeurs par défaut
-        this.__constructor();
+        const defaults = new CoreConfig();
+        Object.assign(this, defaults);
     }
     
     /**
@@ -209,3 +211,12 @@ window.CoreConfig = CoreConfig;
 
 // Instance globale
 window.C2R_CONFIG = new CoreConfig();
+
+// Fonction de confirmation centralisee
+window.c2rConfirm = function(message) {
+    const cfg = window.C2R_CONFIG?.ui;
+    if (cfg && cfg.confirmDialogs === false) {
+        return true;
+    }
+    return confirm(message);
+};

--- a/js/modules/profile/profile-system.js
+++ b/js/modules/profile/profile-system.js
@@ -36,7 +36,8 @@ class ProfileSystem {
                     sidebarPosition: 'left',
                     showWelcomeMessage: true,
                     fontSize: 'medium',
-                    animations: true
+                    animations: true,
+                    confirmDialogs: true
                 },
                 defaultApps: ['notepad', 'todolist'],
                 restrictions: {
@@ -53,7 +54,8 @@ class ProfileSystem {
                     sidebarPosition: 'left',
                     showWelcomeMessage: true,
                     fontSize: 'medium',
-                    animations: true
+                    animations: true,
+                    confirmDialogs: true
                 },
                 defaultApps: ['notepad', 'todolist', 'weather'],
                 restrictions: {
@@ -70,7 +72,8 @@ class ProfileSystem {
                     sidebarPosition: 'left',
                     showWelcomeMessage: false,
                     fontSize: 'small',
-                    animations: false
+                    animations: false,
+                    confirmDialogs: true
                 },
                 defaultApps: ['notepad', 'htmlformatter', 'markdownreader'],
                 restrictions: {
@@ -87,7 +90,8 @@ class ProfileSystem {
                     sidebarPosition: 'left',
                     showWelcomeMessage: true,
                     fontSize: 'large',
-                    animations: true
+                    animations: true,
+                    confirmDialogs: true
                 },
                 defaultApps: ['notepad', 'todolist'],
                 restrictions: {

--- a/js/modules/ui/ui-core.js
+++ b/js/modules/ui/ui-core.js
@@ -106,6 +106,7 @@ class UICore {
             
             if (preferences) {
                 this.applyPreferences(preferences);
+                this.config.save();
             }
         }
     }
@@ -126,9 +127,13 @@ class UICore {
         if (preferences.fontSize) {
             this.setFontSize(preferences.fontSize);
         }
-        
+
         if (preferences.animations !== undefined) {
             this.setAnimations(preferences.animations);
+        }
+
+        if (preferences.confirmDialogs !== undefined) {
+            this.setConfirmDialogs(preferences.confirmDialogs);
         }
     }
     
@@ -178,6 +183,14 @@ class UICore {
             sidebarPositionToggle.addEventListener('change', (e) => {
                 const isRight = e.target.checked;
                 this.setSidebarPosition(isRight ? 'right' : 'left');
+                this.savePreferences();
+            });
+        }
+
+        const confirmDialogsToggle = document.getElementById('confirm-dialogs-toggle');
+        if (confirmDialogsToggle) {
+            confirmDialogsToggle.addEventListener('change', (e) => {
+                this.setConfirmDialogs(e.target.checked);
                 this.savePreferences();
             });
         }
@@ -361,6 +374,7 @@ class UICore {
         const themeToggle = document.getElementById('theme-toggle');
         const welcomeToggle = document.getElementById('welcome-toggle');
         const sidebarToggle = document.getElementById('sidebar-position-toggle');
+        const confirmToggle = document.getElementById('confirm-dialogs-toggle');
         
         if (themeToggle) {
             themeToggle.checked = preferences.theme === 'dark';
@@ -372,6 +386,10 @@ class UICore {
         
         if (sidebarToggle) {
             sidebarToggle.checked = preferences.sidebarPosition === 'right';
+        }
+
+        if (confirmToggle) {
+            confirmToggle.checked = preferences.confirmDialogs !== false;
         }
     }
     
@@ -457,7 +475,7 @@ class UICore {
             
             if (user) {
                 const newRole = user.role === 'admin' ? 'user' : 'admin';
-                if (confirm(`Changer le rôle de ${user.email} vers ${newRole} ?`)) {
+                if (c2rConfirm(`Changer le rôle de ${user.email} vers ${newRole} ?`)) {
                     user.role = newRole;
                     userCore.saveUsers();
                     this.refreshAdminPanel();
@@ -482,7 +500,7 @@ class UICore {
             const users = userCore.getAllUsers();
             const user = users.find(u => u.id === userId);
             
-            if (user && confirm(`Êtes-vous sûr de vouloir supprimer l'utilisateur ${user.email} ?`)) {
+            if (user && c2rConfirm(`Êtes-vous sûr de vouloir supprimer l'utilisateur ${user.email} ?`)) {
                 if (userCore.deleteUser(userId)) {
                     this.refreshAdminPanel();
                     this.showNotification(`Utilisateur ${user.email} supprimé`, 'warning');
@@ -537,7 +555,7 @@ class UICore {
      * Gérer la déconnexion
      */
     handleLogout() {
-        if (confirm('Êtes-vous sûr de vouloir vous déconnecter ?')) {
+        if (c2rConfirm('Êtes-vous sûr de vouloir vous déconnecter ?')) {
             const userCore = window.C2R_SYSTEM?.userCore;
             if (userCore) {
                 userCore.logout();
@@ -858,6 +876,15 @@ class UICore {
     setAnimations(enabled) {
         document.body.setAttribute('data-animations', enabled ? 'enabled' : 'disabled');
     }
+
+    /**
+     * Définir l'utilisation des pop-ups de confirmation
+     * @param {boolean} enabled - Activés
+     */
+    setConfirmDialogs(enabled) {
+        this.config.ui.confirmDialogs = enabled;
+        this.config.save();
+    }
     
     /**
      * Basculer la sidebar
@@ -941,7 +968,8 @@ class UICore {
                 sidebarPosition: document.body.classList.contains('sidebar-right') ? 'right' : 'left',
                 showWelcomeMessage: document.getElementById('welcome-toggle')?.checked ?? true,
                 fontSize: document.body.getAttribute('data-font-size') || 'medium',
-                animations: document.body.getAttribute('data-animations') !== 'disabled'
+                animations: document.body.getAttribute('data-animations') !== 'disabled',
+                confirmDialogs: document.getElementById('confirm-dialogs-toggle')?.checked ?? true
             };
             
             userCore.updatePreferences(preferences);

--- a/js/modules/user/user-core.js
+++ b/js/modules/user/user-core.js
@@ -46,7 +46,8 @@ class UserCore {
                 sidebarPosition: 'left',
                 showWelcomeMessage: true,
                 fontSize: 'medium',
-                animations: true
+                animations: true,
+                confirmDialogs: true
             },
             installedApps: ['notepad', 'todolist', 'weather'],
             appOrder: ['notepad', 'todolist', 'weather'],
@@ -96,7 +97,8 @@ class UserCore {
                     sidebarPosition: 'left',
                     showWelcomeMessage: true,
                     fontSize: 'medium',
-                    animations: true
+                    animations: true,
+                    confirmDialogs: true
                 },
                 installedApps: [],
                 appOrder: [],

--- a/tests/confirm-dialogs.test.js
+++ b/tests/confirm-dialogs.test.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('c2rConfirm', () => {
+  beforeAll(() => {
+    const script = fs.readFileSync(path.resolve(__dirname, '../js/modules/core/config.js'), 'utf8');
+    window.eval(script);
+  });
+
+  test('ignore confirm when disabled', () => {
+    window.C2R_CONFIG.ui.confirmDialogs = false;
+    global.confirm = jest.fn().mockReturnValue(false);
+    const result = window.c2rConfirm('Question?');
+    expect(result).toBe(true);
+    expect(global.confirm).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- correct `CoreConfig.reset()` to restore default values
- persist the `confirmDialogs` option when toggling from the UI
- save preferences during loading
- document that the setting is remembered
- add a unit test for `c2rConfirm`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68422cb215c4832eb68f8c989180b804