### PR TITLE
fix: navigation mobile

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # 📝 C2R OS - Journal des modifications
 
+## [1.1.7] - 2025-06-11 "NavFix"
+
+### ✅ Correctifs mobiles
+- Les liens de la barre de navigation basse possèdent maintenant l'attribut `data-page` pour fonctionner correctement sur petit écran.
+
 ## [1.1.6] - 2025-06-11 "PWAfix"
 
 ### 🗑️ Nettoyage

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -5,7 +5,7 @@ S'occupe du thème, de la navigation et des notifications. Il adapte l'interface
 Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, alignée à droite du texte. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile. Une correction assure également que la poubelle reste rouge sur mobile.
 La petite croix fermant la liste déroulante des applications sur mobile adopte elle aussi une teinte neutre.
 
-La barre de navigation basse a été entièrement revue pour s'approcher d'une véritable application mobile. Elle s'affiche en noir plein écran sous 768 px, avec des icônes blanches. L'icône active passe en rouge `#ff1f1f` et le bouton central **Profil** est mis en valeur par un cercle blanc. Un appui déclenche une petite vibration si le navigateur le permet. Le bouton **Applications** utilise désormais le pictogramme `fa-robot`.
+La barre de navigation basse a été entièrement revue pour s'approcher d'une véritable application mobile. Elle s'affiche en noir plein écran sous 768 px, avec des icônes blanches. L'icône active passe en rouge `#ff1f1f` et le bouton central **Profil** est mis en valeur par un cercle blanc. Un appui déclenche une petite vibration si le navigateur le permet. Le bouton **Applications** utilise désormais le pictogramme `fa-robot`. Les liens de cette barre portent aussi l'attribut `data-page` pour rester fonctionnels sur mobile.
 
 La page Profil permet de réordonner visuellement les applications installées grâce à SortableJS. Un bouton de déconnexion est également présent sur cette page.
 

--- a/index.html
+++ b/index.html
@@ -322,19 +322,19 @@
 
     <!-- Barre de navigation mobile -->
     <nav class="bottom-nav mobile-only" id="bottomNav">
-        <a href="#home" class="nav-link active" data-section="home" aria-label="Accueil">
+        <a href="#home" class="nav-link active" data-section="home" data-page="home" aria-label="Accueil">
             <i class="fa-solid fa-home"></i>
         </a>
-        <a href="#store" class="nav-link" data-section="store" aria-label="Store">
+        <a href="#store" class="nav-link" data-section="store" data-page="store" aria-label="Store">
             <i class="fa-solid fa-store"></i>
         </a>
-        <a href="#profile" class="nav-link profile-link" data-section="profile" aria-label="Profil">
+        <a href="#profile" class="nav-link profile-link" data-section="profile" data-page="profile" aria-label="Profil">
             <i class="fa-solid fa-user"></i>
         </a>
         <button class="nav-link" id="mobile-apps-btn" aria-label="Applications">
             <i class="fa-solid fa-robot"></i>
         </button>
-        <a href="#contact" class="nav-link" data-section="contact" aria-label="Contact">
+        <a href="#contact" class="nav-link" data-section="contact" data-page="contact" aria-label="Contact">
             <i class="fa-solid fa-envelope"></i>
         </a>
     </nav>
@@ -431,7 +431,6 @@
 
     <!-- Point d'entrée principal -->
     <!-- Correctif mobile pour le menu hamburger -->
-    <script src="js/mobile-fix.js"></script>
     <script src="js/sidebar-minimal.js"></script>
     <script src="js/bottom-nav.js"></script>
     <script>

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.6",
+  "version": "1.1.7",
   "build": "2025-06-11",
   "codename": "Genesis",
   "description": "Premier déploiement du système C2R OS",


### PR DESCRIPTION
## Summary
- désactiver la référence à `mobile-fix.js`
- ajouter `data-page` sur les liens de la barre mobile
- documenter la correction de navigation mobile
- mettre à jour le numéro de version et le changelog

## Testing
- `npm test` *(échoue : jest non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_68434d33f1dc832ea8bba95b1a1d1e2f