### PR TITLE
Revert PWA fullscreen

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,5 @@
 # 📝 C2R OS - Journal des modifications
 
-## [1.1.7] - 2025-06-12 "PWA fullscreen"
-
-### 📱 Amélioration mobile
-- Le manifeste définit désormais `display: fullscreen` pour une installation PWA
-  réellement en plein écran sur smartphone.
-
 ## [1.1.6] - 2025-06-11 "PWAfix"
 
 ### 🗑️ Nettoyage

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "C2R OS",
   "short_name": "C2R",
   "start_url": "./index.html",
-  "display": "fullscreen",
+  "display": "standalone",
   "orientation": "portrait",
   "background_color": "#000000",
   "theme_color": "#000000",

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.1.7",
-  "build": "2025-06-12",
+  "version": "1.1.6",
+  "build": "2025-06-11",
   "codename": "Genesis",
   "description": "Premier déploiement du système C2R OS",
   "core_modules": [


### PR DESCRIPTION
## Notes
- suppression de la section *PWA fullscreen* du changelog
- retour du `display` à `standalone` dans le manifeste
- rétablissement de la version **1.1.6**

## Tests
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684357465bbc832eae87074043e6f21d