### PR TITLE
Revenir à la version 1.1.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,5 @@
 # 📝 C2R OS - Journal des modifications
 
-## [1.1.6] - 2025-06-11 "PWAfix"
-
-### 🗑️ Nettoyage
-- Suppression des icônes binaires du manifeste mobile pour alléger le dépôt.
-- Le manifeste reste présent pour permettre un affichage plein écran sur mobile.
-
 ## [1.1.5] - 2025-06-11 "PWA"
 
 ### 📱 Support mobile

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -13,4 +13,4 @@ La sidebar propose un mode compact activé par un bouton dans son en-tête. L'ic
 
 La barre latérale bénéficie d'un fond dégradé gris et d'une ombre pour s'intégrer harmonieusement aux thèmes sombre et clair. Le bouton hamburger a été supprimé au profit de cette barre de navigation basse.
 Une page **Contact** est disponible pour accéder rapidement aux informations de support.
-Depuis la version 1.1.6, un fichier `manifest.json` avec des icônes encodées en base64 et des meta tags permet d'installer C2R OS sur mobile en plein écran.
+Depuis la version 1.1.5, un fichier `manifest.json` avec des icônes encodées en base64 et des meta tags permet d'installer C2R OS sur mobile en plein écran.

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.6",
+  "version": "1.1.5",
   "build": "2025-06-11",
   "codename": "Genesis",
   "description": "Premier déploiement du système C2R OS",


### PR DESCRIPTION
## Notes
- Les tests Jest ne se lancent pas (`jest` absent).

## Summary
- mise à jour `version.json` pour revenir à 1.1.5
- suppression du changelog 1.1.6
- actualisation de la documentation UI


------
https://chatgpt.com/codex/tasks/task_e_684358e21cbc832e8a2b2cba1c2de5ac