### PR TITLE
Ajout tuile installation PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - Nouvelle application **Formation ChatGPT** : apprenez à exploiter ChatGPT grâce à des exemples interactifs et un quiz.
 - Une page **Contact** fait son apparition pour joindre l'équipe de développement par mail ou téléphone.
 - Grâce à un manifeste web utilisant des icônes encodées en base64 et aux meta tags dédiés, le site peut être installé sur mobile en plein écran.
+- Une tuile dédiée propose l'installation en mode PWA lorsqu'on consulte la page d'accueil sur mobile.
 - La barre de navigation basse adopte désormais un style proche d'une application mobile : fond noir, icônes blanches et rouge actif. Le bouton central Profil est mis en avant par un cercle blanc.
 - L'application **Formation ChatGPT** propose désormais un cours en dix pages avec navigation pour une prise en main intuitive.
 - La page d'accueil présente des tuiles explicatives pour découvrir le fonctionnement du site.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # 📝 C2R OS - Journal des modifications
 
+## [1.1.6] - 2025-06-12 "InstallTile"
+
+### 📲 Installation PWA
+- Une nouvelle tuile sur la page d'accueil propose d'installer l'application en mode PWA lorsque vous êtes sur mobile.
+
 ## [1.1.5] - 2025-06-11 "PWA"
 
 ### 📱 Support mobile

--- a/index.html
+++ b/index.html
@@ -123,6 +123,11 @@
                             <h3>Configurez le système</h3>
                             <p>Accédez aux options avancées si vous disposez des droits.</p>
                         </div>
+                        <div class="card info-tile" id="pwa-install-tile" style="display:none;">
+                            <span data-icon="install"></span>
+                            <h3>Installer C2R OS</h3>
+                            <p>Ajoutez l'application sur votre écran d'accueil.</p>
+                        </div>
                     </div>
 
                     <div id="daily-tip" class="daily-tip">

--- a/js/main.js
+++ b/js/main.js
@@ -1,12 +1,31 @@
 /**
  * C2R OS - Point d'entrée principal
- * Version: 1.0.0
+ * Version: 1.1.6
  * Description: Système d'exploitation dans le navigateur avec architecture modulaire
  */
+
+let deferredPwaPrompt = null;
+
+window.addEventListener('beforeinstallprompt', (e) => {
+    e.preventDefault();
+    deferredPwaPrompt = e;
+    const tile = document.getElementById('pwa-install-tile');
+    if (tile) {
+        tile.style.display = 'flex';
+    }
+});
 
 // Initialisation du système C2R OS
 document.addEventListener('DOMContentLoaded', async () => {
     console.log('🚀 Initialisation C2R OS...');
+
+    const tile = document.getElementById('pwa-install-tile');
+    if (tile) {
+        const standalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone;
+        if (standalone) {
+            tile.style.display = 'none';
+        }
+    }
     
     try {
         // Vérifier la disponibilité des modules
@@ -145,6 +164,19 @@ function setupGlobalEventHandlers() {
     
     // Configurer les gestionnaires d'authentification
     setupAuthEventListeners();
+
+    const pwaTile = document.getElementById('pwa-install-tile');
+    if (pwaTile) {
+        pwaTile.addEventListener('click', async () => {
+            if (!deferredPwaPrompt) return;
+            deferredPwaPrompt.prompt();
+            const result = await deferredPwaPrompt.userChoice;
+            if (result.outcome === 'accepted') {
+                pwaTile.style.display = 'none';
+            }
+            deferredPwaPrompt = null;
+        });
+    }
 }
 
 /**

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.1.5",
-  "build": "2025-06-11",
+  "version": "1.1.6",
+  "build": "2025-06-12",
   "codename": "Genesis",
   "description": "Premier déploiement du système C2R OS",
   "core_modules": [


### PR DESCRIPTION
## Notes
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

## Summary
- insertion d'une tuile « Installer C2R OS » sur la page d'accueil
- prise en charge de l'événement `beforeinstallprompt` dans `main.js`
- gestion du clic sur la tuile pour afficher la demande d'installation
- mise à jour du `README` et du `changelog`
- incrément de version à 1.1.6

## Testing
- `npm test` *(échoue : jest non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_684370f71ce0832e846da0a3be397bff