### PR TITLE
Réduction icônes mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Le Store propose un bouton unique pour installer ou désinstaller une applicatio
 - Correction: en mode mobile, la poubelle conserve bien sa couleur rouge.
 - En affichage mobile, un bouton **Applications** apparaît dans la barre de navigation basse.
 - La croix du menu mobile adopte la même couleur neutre que les autres boutons.
-- Les icônes de la liste d'applications mobile sont plus petites et adoptent la couleur secondaire pour un rendu plus sobre.
+- Les icônes de la liste d'applications mobile sont encore plus petites et adoptent la couleur secondaire pour un rendu plus compact.
 - Depuis la version 1.1.0, les applications installées peuvent être réordonnées par glisser-déposer dans la page Profil.
 - Un bouton de déconnexion est disponible dans la page Profil.
 - La barre latérale intègre un bouton de réduction : l'icône passe d'une croix à un petit carré suivant l'état de la barre.

--- a/changelog.md
+++ b/changelog.md
@@ -1,30 +1,22 @@
 # 📝 C2R OS - Journal des modifications
 
-09kjmh-codex/2025-06-06
 ## [1.1.6] - 2025-06-12 "ContactForm"
 
 ### ✉️ Formulaire de contact
 - La page Contact intègre un formulaire pour envoyer un message directement depuis l'interface.
-=======
-4uf1po-codex/2025-06-06
 ## [1.1.6] - 2025-06-12 "UI"
 
 ### 📱 Barre de navigation mobile
 - Agrandissement de la barre inférieure à 72 px pour une meilleure accessibilité tactile.
-=======
-tzctt3-codex/2025-06-06
 ## [1.1.6] - 2025-06-12 "InstallTile"
 
 ### 📲 Installation PWA
 - Une nouvelle tuile sur la page d'accueil propose d'installer l'application en mode PWA lorsque vous êtes sur mobile.
-=======
 ## [1.1.6] - 2025-06-12 "UI Refinement"
 
 ### 🎨 Ajustements visuels
 - Icônes du menu d'applications mobile réduites et teintées en couleur secondaire pour un style plus sobre.
-main
-main
-main
+- Taille des icônes du menu mobile encore diminuée pour gagner de la place.
 
 ## [1.1.5] - 2025-06-11 "PWA"
 

--- a/css/bottom-nav.css
+++ b/css/bottom-nav.css
@@ -120,6 +120,11 @@
 
 /* Icônes plus discrètes dans la liste mobile */
 .mobile-app-item .app-icon .icon {
-    font-size: 1.2rem;
+    font-size: 1rem;
     color: var(--c2r-text-secondary);
+}
+
+/* Taille réduite de la flèche dans la liste mobile */
+.mobile-app-item .material-symbols-outlined {
+    font-size: 1rem;
 }

--- a/docs/ui-readme.md
+++ b/docs/ui-readme.md
@@ -4,7 +4,7 @@ S'occupe du thème, de la navigation et des notifications. Il adapte l'interface
 
 Depuis la version actuelle, le Store utilise la méthode `toggleApp(appId)` pour installer ou désinstaller une application. L'icône « plus » devient une poubelle rouge, alignée à droite du texte. L'affichage sombre conserve cette couleur et la taille des icônes est réduite pour un meilleur rendu mobile. Une correction assure également que la poubelle reste rouge sur mobile.
 La petite croix fermant la liste déroulante des applications sur mobile adopte elle aussi une teinte neutre.
-Les icônes de cette liste sont désormais plus petites et utilisent la couleur secondaire pour rester discrètes sur mobile.
+Les icônes de cette liste ont été encore réduites et utilisent la couleur secondaire pour rester discrètes sur mobile.
 
 La barre de navigation basse a été entièrement revue pour s'approcher d'une véritable application mobile. Elle s'affiche en noir plein écran sous 768 px, avec des icônes blanches. L'icône active passe en rouge `#ff1f1f` et le bouton central **Profil** est mis en valeur par un cercle blanc. Un appui déclenche une petite vibration si le navigateur le permet. Le bouton **Applications** utilise désormais le pictogramme `fa-robot`.
 


### PR DESCRIPTION
## Notes
- Diminution de la taille des icônes dans la liste d'applications mobile
- Mise à jour de la documentation associée
- Nettoyage du `changelog.md`

## Tests
- `npm test` *(échec : jest non installé)*

------
https://chatgpt.com/codex/tasks/task_e_6843dfb82934832ea35b35a0fd6357d3